### PR TITLE
remove unnecessary recursive flag

### DIFF
--- a/share/cht.sh.txt
+++ b/share/cht.sh.txt
@@ -149,7 +149,7 @@ mkdir -p "$HOME/.cht.sh/"
 lines=$(tput lines)
 
 TMP1=$(mktemp /tmp/cht.sh.XXXXXXXXXXXXX)
-trap 'rm -rf $TMP1 $TMP2' EXIT
+trap 'rm -f $TMP1 $TMP2' EXIT
 trap 'true' INT
 
 if ! [ -e "$HOME/.cht.sh/.hushlogin" ] && [ -z "$this_query" ]; then


### PR DESCRIPTION
You are dealing with files, not directories, so using recursive flag for removal can only create potential disaster scenarios (in case variable is blank for example).

Most likely, you don't need the `-f` flag either.