### PR TITLE
Get the Emacs to cheat.sh supported language mapping list up and going

### DIFF
--- a/lib/languages_data.py
+++ b/lib/languages_data.py
@@ -133,6 +133,68 @@ ATOM_FT_NAME = {
 }
 
 EMACS_FT_NAME = {
+    "asm-mode"             : "asm",
+    "awk-mode"             : "awk",
+    "sh-mode"              : "bash",
+    # basic
+    "brainfuck-mode"       : "bf",
+    # chapel
+    "clojure-mode"         : "clojure",
+    "coffee-mode"          : "coffee",
+    "c++-mode"             : "cpp",
+    "c-mode"               : "c",
+    "csharp-mode"          : "csharp",
+    "d-mode"               : "d",
+    "dart-mode"            : "dart",
+    "dylan-mode"           : "dylan",
+    # delphi -- not in Melpa, but I think there's one out there.
+    "emacs-lisp-mode"      : "elisp",
+    # elixir
+    "elm-mode"             : "elm",
+    "erlang-mode"          : "erlang",
+    # factor
+    # forth
+    "fortran-mode"         : "fortran",
+    "fsharp-mode"          : "fsharp",
+    "go-mode"              : "go",
+    "groovy-mode"          : "groovy",
+    "haskell-mode"         : "haskell",
+    # "hy-mode"
+    "java-mode"            : "java",
+    "js-jsx-mode"          : "js",
+    "js-mode"              : "js",
+    "js2-jsx-mode"         : "js",
+    "js2-mode"             : "js",
+    "julia-mode"           : "julia",
+    "kotlin-mode"          : "kotlin",
+    "lisp-interaction-mode": "lisp",
+    "lisp-mode"            : "lisp",
+    # lua
+    # mathematica
+    "matlab-mode"          : "matlab",
+    # mongo
+    "objc-mode"            : "objective-c",
+    # ocaml
+    "perl-mode"            : "perl",
+    # perl6
+    "php-mode"             : "php",
+    # psql
+    "python-mode"          : "python",
+    # python3
+    # r -- ess looks it, but I don't know the mode name off hand
+    "racket-mode"          : "racket",
+    "ruby-mode"            : "ruby",
+    "rust-mode"            : "rust",
+    "solidity-mode"        : "solidity",
+    "scala-mode"           : "scala",
+    "scheme-mode"          : "scheme",
+    "sql-mode"             : "sql",
+    "swift-mode"           : "swift",
+    "tcl-mode"             : "tcl",
+    # tcsh
+    # vb
+    # vbnet
+    # vim
 }
 
 SUBLIME_FT_NAME = {


### PR DESCRIPTION
I've put this together by going though `LEXER` and looking for the mode that matches. Where there isn't one I've left a comment as a reminder for someone to fill in that blank.

I've also included a reminder for hylang.org as it might be nice to have it in here too.