### PR TITLE
Fix ksh93 hack that breaks dash.

### DIFF
--- a/share/cht.sh-posix.txt
+++ b/share/cht.sh-posix.txt
@@ -35,7 +35,7 @@ case "$OSTYPE" in
 esac
 
 # for KSH93
-if ! local foo 2>/dev/null; then
+if echo $KSH_VERSION | grep -q ' 93' && ! local foo 2>/dev/null; then
   alias local=typeset
 fi
 


### PR DESCRIPTION
The dash shell fails to implement local command properly, and errors
out in case such simple as "if ! local foo; then ..."