### PR TITLE
Fix: Missing args in Sub-commands

### DIFF
--- a/share/cht.sh.txt
+++ b/share/cht.sh.txt
@@ -460,5 +460,5 @@ while true; do
     version)        cmd_name=version;;
     *)              cmd_name="query $cmd_name";;
   esac
-  cmd_$cmd_name $cmdargs 
+  cmd_$cmd_name $cmd_args 
 done


### PR DESCRIPTION
It should be a typo.
The args parsed into `cmd_args`, but used `$cmdargs` for passing args.