### PR TITLE
Escape question marks in README.md curl examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,9 +151,9 @@ so they can be pasted into a program in this language directly. Text comments, i
 ```
 
 If you don't need text comments in the answer, you can eliminate them
-using a special option `?Q`:
+using a special option `\?Q`:
 ```lua
-    $ curl cht.sh/lua/table+keys?Q
+    $ curl cht.sh/lua/table+keys\?Q
     local keyset={}
     local n=0
 
@@ -163,15 +163,15 @@ using a special option `?Q`:
     end
 ```
 
-And if you don't need syntax highlighting, switch it off using `?T`.
+And if you don't need syntax highlighting, switch it off using `\?T`.
 You can combine the options together:
 
 ```
-    curl cht.sh/go/reverse+a+list?Q
-    curl cht.sh/python/random+list+elements?Q
-    curl cht.sh/js/parse+json?Q
-    curl cht.sh/lua/merge+tables?QT
-    curl cht.sh/clojure/variadic+function?QT
+    curl cht.sh/go/reverse+a+list\?Q
+    curl cht.sh/python/random+list+elements\?Q
+    curl cht.sh/js/parse+json\?Q
+    curl cht.sh/lua/merge+tables\?QT
+    curl cht.sh/clojure/variadic+function\?QT
 ```
 
 Full list of all options described below and in `/:help`.


### PR DESCRIPTION
Addresses issue #113, seems to be a shell-specific issue (zsh for me when I reproduced it) but escaping `?` with `\?` works for both bash and zsh. Seems like a cleaner solution than adding quotes around all curl commands in the README.md.