### PR TITLE
Fix various typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,5 +4,5 @@ contribute to cheat.sh and make it better and more useful:
 1. Suggest a GitHub repository (or other information source) to be attached to cheat.sh. Just create an issue for it, where the name and the URL of the repository is specified. Please keep in mind, that the repository's license has to permit its usage by cheat.sh;
 2. Create an adapter for some repository and add it to cheat.sh;
 3. Create a Editor plugin for cheat.sh;
-4. Create a new cheat sheet in one of its upsream repositories;
+4. Create a new cheat sheet in one of its upstream repositories;
 5. Go through the list of open issues, and try to fix some of them, or at least understand and share your opinion about them, if you have it.

--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ Type `help` for other internal `cht.sh` commands.
 ```
 
 The `cht.sh` client has its configuration file which is located at `~/.cht.sh/cht.sh.conf`
-(location of the file can be overriden by the environment variable `CHTSH_CONF`).
+(location of the file can be overridden by the environment variable `CHTSH_CONF`).
 Use it to specify query options that you would use with each query.
 For example, to switch syntax highlighting off create the file with the following
 content:

--- a/lib/adapter/adapter.py
+++ b/lib/adapter/adapter.py
@@ -13,7 +13,7 @@ from config import CONFIG
 
 class AdapterMC(type):
     """
-    Adapater Metaclass.
+    Adapter Metaclass.
     Defines string representation of adapters
     """
     def __repr__(cls):
@@ -125,7 +125,7 @@ class Adapter(with_metaclass(AdapterMC, object)):
         #
         # if _get_page() returns a dict, use the dictionary
         # for the answer. It is possible to specify some
-        # usefule properties as the part of the answer
+        # useful properties as the part of the answer
         # (e.g. "cache")
         # answer by _get_page() always overrides all default properties
         #
@@ -148,7 +148,7 @@ class Adapter(with_metaclass(AdapterMC, object)):
         If name `self._repository_url` for the class is not specified, return None
         It is possible that several adapters has the same repository_url,
         in this case they should use the same local directory.
-        If for some reason the local repository location should be overriden
+        If for some reason the local repository location should be overridden
         (e.g. if several different branches of the same repository are used)
         if should set in `self._local_repository_location` of the adapter.
         If `cheat_sheets_location` is specified, return path of the cheat sheets

--- a/lib/adapter/cmd.py
+++ b/lib/adapter/cmd.py
@@ -34,7 +34,7 @@ class Fosdem(CommandAdapter):
 
     https://www.youtube.com/watch?v=PmiK0JCdh5A
 
-    `sudo` is used here beause the session was running under
+    `sudo` is used here because the session was running under
     a different user; to be able to use the command via sudo,
     the following `/etc/suders` entry was added:
 

--- a/lib/adapter/git_adapter.py
+++ b/lib/adapter/git_adapter.py
@@ -12,14 +12,14 @@ def _get_filenames(path):
 
 class RepositoryAdapter(Adapter):
     """
-    Implements methos needed to handle standard
+    Implements methods needed to handle standard
     repository based adapters.
     """
 
     def _get_list(self, prefix=None):
         """
         List of files in the cheat sheets directory
-        with the extenstion removed
+        with the extension removed
         """
 
         answer = _get_filenames(
@@ -55,7 +55,7 @@ class RepositoryAdapter(Adapter):
 class GitRepositoryAdapter(RepositoryAdapter):    #pylint: disable=abstract-method
     """
     Implements all methods needed to handle cache handling
-    for git-repository-based adatpers
+    for git-repository-based adapters
     """
 
     @classmethod

--- a/lib/adapter/question.py
+++ b/lib/adapter/question.py
@@ -30,7 +30,7 @@ class Question(UpstreamAdapter):
 
     If the program is not found, fallback to the superclass `UpstreamAdapter`,
     which queries the upstream server (by default https://cheat.sh/)
-    fot the answer
+    for the answer
     """
 
     _adapter_name = "question"

--- a/lib/config.py
+++ b/lib/config.py
@@ -5,7 +5,7 @@ All configurable parameters are stored in the global variable CONFIG,
 the only variable which is exported from the module.
 
 Default values of all configuration parameters are specified
-in the `_CONFIG` dictionary. Those parameters can be overriden
+in the `_CONFIG` dictionary. Those parameters can be overridden
 by three means:
     * config file `etc/config.yaml` located in the work dir
     * config file `etc/config.yaml` located in the project dir
@@ -23,7 +23,7 @@ recommend that you use the config file located in the project dir,
 except the cases when you use your own cheat.sh fork, and thus
 configuration is a part of the project repository.
 In all other cases `WORKDIR/etc/config.yaml` should be preferred.
-Location of this config file can be overriden by the `CHEATSH_PATH_CONFIG`
+Location of this config file can be overridden by the `CHEATSH_PATH_CONFIG`
 environment variable.
 
 Configuration parameters set by environment variables are mapped
@@ -35,7 +35,7 @@ in this way:
 For instance, an environment variable named `CHEATSH_SERVER_PORT`
 specifies the value for the `server.port` configuration parameter.
 
-Only paramters that imply scalar values (integer or string)
+Only parameters that imply scalar values (integer or string)
 can be set using environment variables, for the rest config files
 should be used. If a parameter implies an integer, and the value
 specified by an environment variable is not an integer, it is ignored.
@@ -139,7 +139,7 @@ _CONFIG = {
 class Config(dict):
     """
     configuration dictionary that handles relative
-    pathes properly (making them relative to path.workdir)
+    paths properly (making them relative to path.workdir)
     """
 
     def _absolute_path(self, val):

--- a/lib/fetch.py
+++ b/lib/fetch.py
@@ -1,7 +1,7 @@
 """
 Repositories fetch and update
 
-Ths module makes real network and OS interaction,
+This module makes real network and OS interaction,
 and the adapters only say how exctly this interaction
 should be done.
 

--- a/share/cht.sh.txt
+++ b/share/cht.sh.txt
@@ -95,7 +95,7 @@ cheat sheets repositories will be fetched.
 It takes approximately 1G of the disk space.
 
 Default installation location:  ~/.cheat.sh/
-It can be overriden by a command line parameter to this script:
+It can be overridden by a command line parameter to this script:
 
     ${0##*/} --standalone-install DIR
 
@@ -191,7 +191,7 @@ EOF
     tail -n 10 "$LOG"
     echo "---"
     echo "See $LOG for more"
-    fatal Could not install python dependecies into the virtual environment
+    fatal Could not install python dependencies into the virtual environment
   }
   echo "$(ve/bin/pip freeze | wc -l) dependencies were successfully installed"
 
@@ -282,8 +282,8 @@ chtsh_mode()
       echo "Configured mode: $mode"
     fi
   else
-    echo "Uknown mode: $mode"
-    echo Suported modes:
+    echo "Unknown mode: $mode"
+    echo Supported modes:
     echo "  auto    use the standalone installation first"
     echo "  lite    use the cheat sheets server directly"
   fi

--- a/share/intro.txt
+++ b/share/intro.txt
@@ -92,7 +92,7 @@ Of course, you can start the shell without the context too:
     {1cht.sh> go http query}
     {1cht.sh> js iterate list}
 
-If you ue predominantly one language but sometime issuing queries about other,
+If you use predominantly one language but sometime issuing queries about other,
 you may prepend the query with {2/}:
 
     {1cht.sh/python>} {2zip lists}

--- a/tests/results/16
+++ b/tests/results/16
@@ -8,7 +8,7 @@ L1 cache reference: 1ns                                   [32m▗              
                              [34m▗▖▗▖▗▖▗▖▗▖▗▖▗▖▗▖▗▖▗▖         [mSSD random read: 16.0us      Disk seek: 2.679433ms        
 Branch mispredict: 3ns       [34m                             [m[32m▗▖▗                          [m[31m▗▖▗▖▗                        [m
 [37m▗▖▗▖▗▖                       [m                                                                                       
-                             Compress 1KB wth Snappy:     Read 1,000,000 bytes         Read 1,000,000 bytes         
+                             Compress 1KB with Snappy:     Read 1,000,000 bytes         Read 1,000,000 bytes         
 L2 cache reference: 4ns      2.0us                        sequentially from memory:    sequentially from disk:      
 [37m▗▖▗▖▗▖▗▖                     [m[34m▗▖▗▖▗▖▗▖▗▖▗▖▗▖▗▖▗▖▗▖         [m3.738us                      947.322us                    
                              [34m▗▖▗▖▗▖▗▖▗▖▗▖▗▖▗▖▗▖▗▖         [m[32m▗                            [m[31m▗                            [m

--- a/tests/results/25
+++ b/tests/results/25
@@ -8,7 +8,7 @@ L1 cache reference: 1ns                                   [32m▗              
                              [34m▗▖▗▖▗▖▗▖▗▖▗▖▗▖▗▖▗▖▗▖         [mSSD random read: 16us        [31m▗▖▗▖▗                        [m
 Branch mispredict: 3ns       [34m                             [m[32m▗▖                           [m                             
 [37m▗▖▗▖▗▖                       [m                                                          Read 1,000,000 bytes         
-                             Compress 1KB wth Snappy:     Read 1,000,000 bytes         sequentially from disk:      
+                             Compress 1KB with Snappy:     Read 1,000,000 bytes         sequentially from disk:      
 L2 cache reference: 4ns      2us                          sequentially from memory:    947us                        
 [37m▗▖▗▖▗▖▗▖                     [m[34m▗▖▗▖▗▖▗▖▗▖▗▖▗▖▗▖▗▖▗▖         [m3us                          [31m▗                            [m
                              [34m▗▖▗▖▗▖▗▖▗▖▗▖▗▖▗▖▗▖▗▖         [m[32m▗                            [m                             

--- a/tests/results/6
+++ b/tests/results/6
@@ -92,7 +92,7 @@ Of course, you can start the shell without the context too:
     [36mcht.sh> go http query[0m
     [36mcht.sh> js iterate list[0m
 
-If you ue predominantly one language but sometime issuing queries about other,
+If you use predominantly one language but sometime issuing queries about other,
 you may prepend the query with [32m/[0m:
 
     [36mcht.sh/python>[0m [32mzip lists[0m

--- a/tests/results/8
+++ b/tests/results/8
@@ -95,7 +95,7 @@ cheat sheets repositories will be fetched.
 It takes approximately 1G of the disk space.
 
 Default installation location:  ~/.cheat.sh/
-It can be overriden by a command line parameter to this script:
+It can be overridden by a command line parameter to this script:
 
     ${0##*/} --standalone-install DIR
 
@@ -191,7 +191,7 @@ EOF
     tail -n 10 "$LOG"
     echo "---"
     echo "See $LOG for more"
-    fatal Could not install python dependecies into the virtual environment
+    fatal Could not install python dependencies into the virtual environment
   }
   echo "$(ve/bin/pip freeze | wc -l) dependencies were successfully installed"
 
@@ -282,8 +282,8 @@ chtsh_mode()
       echo "Configured mode: $mode"
     fi
   else
-    echo "Uknown mode: $mode"
-    echo Suported modes:
+    echo "Unknown mode: $mode"
+    echo Supported modes:
     echo "  auto    use the standalone installation first"
     echo "  lite    use the cheat sheets server directly"
   fi


### PR DESCRIPTION
Fixes #169.

Note that one of the corrections was incorrect: "ue"->"due". I opened [codespell#1413](https://github.com/codespell-project/codespell/issues/1413) to track that issue.