### PR TITLE
Fix: Py3: don't use str.decode()

### DIFF
--- a/lib/adapter/tldr.py
+++ b/lib/adapter/tldr.py
@@ -90,7 +90,7 @@ class Tldr(GitRepositoryAdapter):
             # though it should not happen
             answer = ''
 
-        return answer.decode('utf-8')
+        return answer
 
     @classmethod
     def get_updates_list(cls, updated_files_list):


### PR DESCRIPTION
`str.decode('utf-8')` is obsolete, and `str.decode` has been removed
since Python 3 makes everything Unicode by default. This commit avoids
receiving the following error for the TLDR adapter:
`AttributeError: 'str' object has no attribute 'decode'`