### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/lib/adapter/internal.py
+++ b/lib/adapter/internal.py
@@ -9,7 +9,7 @@ import sys
 import os
 import collections
 
-from fuzzywuzzy import process, fuzz
+from rapidfuzz import process, fuzz
 
 from config import CONFIG
 from .adapter import Adapter
@@ -120,7 +120,7 @@ class UnknownPages(InternalPages):
         else:
             topics_list = [x for x in topics_list if not x.startswith(':')]
 
-        possible_topics = process.extract(topic, topics_list, scorer=fuzz.ratio)[:3]
+        possible_topics = process.extract(topic, topics_list, limit=3, scorer=fuzz.ratio)
         possible_topics_text = "\n".join([("    * %s %s" % x) for x in possible_topics])
         return """
 Unknown topic.

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ flask
 requests
 pygments
 dateutils
-fuzzywuzzy
+rapidfuzz
 redis
 colored
 langdetect
@@ -14,4 +14,3 @@ PyICU
 pycld2
 colorama
 pyyaml
-python-Levenshtein


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2.
For this reason this Pullrequest replaces FuzzyWuzzy with  [rapidfuzz](https://github.com/rhasspy/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed.
Rapidfuzz is:
- Mit licensed so it can be used with the license used by this project
- Is faster than FuzzyWuzzy

Edit: I did just see that cheat.sh still has python2 support which would be broken by this PR