### PR TITLE
Topic lookup speed increase, code quality improvement

### DIFF
--- a/lib/adapter/cmd.py
+++ b/lib/adapter/cmd.py
@@ -130,8 +130,9 @@ class AdapterOeis(CommandAdapter):
             cmd[0] = _get_abspath(cmd[0])
 
         # cut oeis/ off
+        # Space delimiter for args to oeis.sh
         if topic.startswith("oeis/"):
-            topic = topic[5:]
+            topic = topic[5:].replace('+',' ')
 
         return cmd + [topic]
 


### PR DESCRIPTION
## RFC
- ```rfc_describe``` helper function created.
- Topic lookup section changed from parsing ``` curl "https://www.rfc-editor.org/search/rfc_search_detail.php?title=${ARG}" 2>/dev/null \``` to simply doing a ```grep``` of the index file using the ```rfc_describe``` helper function.
- - This is faster because the index file is stored locally.

## OEIS
- hopefully fixed arg passing issue between ```cmd.py``` and ```oeis.sh``` by using a delimiter 