### PR TITLE
more resilliant cmd.py Adapter parsing

### DIFF
--- a/lib/adapter/cmd.py
+++ b/lib/adapter/cmd.py
@@ -130,9 +130,10 @@ class AdapterOeis(CommandAdapter):
             cmd[0] = _get_abspath(cmd[0])
 
         # cut oeis/ off
-        # Space delimiter for args to oeis.sh
+        # Replace all (non numeric and non '-')'s with Spaces to delimit args to oeis.sh
         if topic.startswith("oeis/"):
-            topic = topic[5:].replace('+',' ')
+          topic = topic[5:]
+          topic = re.sub('[^0-9-]', ' ', topic)
 
         return cmd + [topic]
 

--- a/lib/adapter/cmd.py
+++ b/lib/adapter/cmd.py
@@ -130,10 +130,10 @@ class AdapterOeis(CommandAdapter):
             cmd[0] = _get_abspath(cmd[0])
 
         # cut oeis/ off
-        # Replace all (non numeric and non '-')'s with Spaces to delimit args to oeis.sh
+        # Replace all non (numeric, '-') chars with Spaces to delimit args to oeis.sh
         if topic.startswith("oeis/"):
-          topic = topic[5:]
-          topic = re.sub('[^0-9-]', ' ', topic)
+            topic = topic[5:]
+            topic = re.sub('[^0-9-]', ' ', topic)
 
         return cmd + [topic]
 
@@ -155,10 +155,13 @@ class AdapterChmod(CommandAdapter):
         cmd = self._command[:]
 
         # cut chmod/ off
+        # remove all non (alphanumeric, '-') chars
         if topic.startswith("chmod/"):
             topic = topic[6:]
+            topic = re.sub('[^a-z^A-Z^0-9-]', '', topic)
+
 
         return cmd + [topic]
 
     def is_found(self, topic):
-        return True 
+        return True


### PR DESCRIPTION
## Before:
 WORKS: ```curl cheat.sh/oeis/1+2+3+4```  
 WORKS: ```curl cheat.sh/oeis/A2+Python```  
 WORKS:```curl cheat.sh/chmod+777```
 FAILS   : ```curl cheat.sh/oeis/A2/Python```
 FAILS   : ```curl cheat.sh/oeis/1,2,3,4```  
 FAILS   : ```curl cheat.sh/oeis/1#2#3#4```  
 FAILS   : ```curl cheat.sh/oeis/1:2:3:4```  
 FAILS   : ```curl cheat.sh/chmod++777```
 FAILS   : ```curl cheat.sh/chmod+777+```

## Now:
 WORKS: ```curl cheat.sh/oeis/1+2+3+4```  
 WORKS: ```curl cheat.sh/oeis/A2+Python```  
 WORKS : ```curl cheat.sh/oeis/A2/Python```
 WORKS : ```curl cheat.sh/oeis/1,2,3,4```  
 WORKS: ```curl cheat.sh/oeis/1#2#3#4```   
 WORKS: ```curl cheat.sh/oeis/1:2:3:4```  
 WORKS: ```curl cheat.sh/chmod++777```
 WORKS: ```curl cheat.sh/chmod+777+```