### PR TITLE
Chmod and OEIS bug fixes.

### DIFF
--- a/lib/adapter/cmd.py
+++ b/lib/adapter/cmd.py
@@ -130,10 +130,10 @@ class AdapterOeis(CommandAdapter):
             cmd[0] = _get_abspath(cmd[0])
 
         # cut oeis/ off
-        # Replace all non (numeric, '-') chars with Spaces to delimit args to oeis.sh
+        # Replace all non (alphanumeric, '-') chars with Spaces to delimit args to oeis.sh
         if topic.startswith("oeis/"):
             topic = topic[5:]
-            topic = re.sub('[^0-9-]', ' ', topic)
+            topic = re.sub('[^a-zA-Z0-9-]', ' ', topic)
 
         return cmd + [topic]
 

--- a/share/adapters/chmod.sh
+++ b/share/adapters/chmod.sh
@@ -24,7 +24,7 @@ chmod_calc(){
     do
       num=$(echo "obase=2;${p_n:$i:1}" | bc | xargs printf '%03d')
       # If 4 digit input -> process specials
-      if [[ ${#p_n} -eq 4 && $i -eq 0 ]]
+      if [ $i -eq 0 ]
       then
         [ ${num:0:1} -eq 1 ] && setuid='X' || setuid=' '
         [ ${num:1:1} -eq 1 ] && setgid='X' || setgid=' '

--- a/share/adapters/chmod.sh
+++ b/share/adapters/chmod.sh
@@ -16,15 +16,15 @@ chmod_calc(){
   setuid=' '
   setgid=' '
   sticky=' '
-  # If permission number is given calc string
-  if [[ $1 =~ ^-?[0-9]+$ && ${#1} -ge 2 && ${#1} -le 4 ]]
+  # If permission number is given -> calc string
+  if [[ $1 =~ ^-?[0-9]+$ && ${#1} -ge 1 && ${#1} -le 4 ]]
   then
-    p_n=$1
-    for (( i=0; i<${#1}; i++ ))
+    p_n=$(printf "%04s\n" "$1" | tr ' ' '0')
+    for (( i=0; i<${#p_n}; i++ ))
     do
-      num=$(echo "obase=2;${1:$i:1}" | bc | xargs printf '%03d')
-      # If 4 digit input, process specials
-      if [[ ${#1} -eq 4 && $i -eq 0 ]]
+      num=$(echo "obase=2;${p_n:$i:1}" | bc | xargs printf '%03d')
+      # If 4 digit input -> process specials
+      if [[ ${#p_n} -eq 4 && $i -eq 0 ]]
       then
         [ ${num:0:1} -eq 1 ] && setuid='X' || setuid=' '
         [ ${num:1:1} -eq 1 ] && setgid='X' || setgid=' '
@@ -52,8 +52,8 @@ chmod_calc(){
         [ ${num:2:1} -eq 1 ] && X+=('X') || X+=(' ')
       fi
     done
-  # If permission string is given calc number
-  elif [[ ${#1} -le 9 && $(( ${#1} % 3 )) -eq 0 && $1 =~ ^[r,s,S,t,T,w,x,-]+$ ]]
+  # If permission string is given -> calc number
+  elif [[ ${#1} -eq 9 && $1 =~ ^[r,s,S,t,T,w,x,-]+$ ]]
   then
     p_s=$1
     num=0
@@ -63,24 +63,24 @@ chmod_calc(){
     [[ 'tT' =~ ${p_s:8:1} ]] && sticky='X' && num=$((num+1))
     [ ${num} -gt 0 ] && p_n+="$num"
     # Calculate rest of p_n number while populating arrays for table
-    for (( i=0; i<${#1}; i+=0 ))
+    for (( i=0; i<${#p_s}; i+=0 ))
     do
       num=0
-      [[ ${1:$i:1} == 'r' ]] && R+=('X') || R+=(' ')
-      [[ ${1:$((i++)):1} == 'r' ]] && let num++
+      [[ ${p_s:$i:1} == 'r' ]] && R+=('X') || R+=(' ')
+      [[ ${p_s:$((i++)):1} == 'r' ]] && let num++
       num=$(( num << 1 ))
-      [[ ${1:$i:1} == 'w' ]] && W+=('X') || W+=(' ')
-      [[ ${1:$((i++)):1} == 'w' ]] && let num++
+      [[ ${p_s:$i:1} == 'w' ]] && W+=('X') || W+=(' ')
+      [[ ${p_s:$((i++)):1} == 'w' ]] && let num++
       num=$(( num << 1 ))
       if [ $i -lt 6 ]
       then
-        [[ "tT" =~ ${1:$i:1} ]] && return 1
-        [[ "sx" =~ ${1:$i:1} ]] && X+=('X') || X+=(' ')
-        [[ "sx" =~ ${1:$((i++)):1} ]] && let num++
+        [[ "tT" =~ ${p_s:$i:1} ]] && return 1
+        [[ "sx" =~ ${p_s:$i:1} ]] && X+=('X') || X+=(' ')
+        [[ "sx" =~ ${p_s:$((i++)):1} ]] && let num++
       else
-        [[ "sS" =~ ${1:$i:1} ]] && return 1
-        [[ "tx" =~ ${1:$i:1} ]] && X+=('X') || X+=(' ')
-        [[ "tx" =~ ${1:$((i++)):1} ]] && let num++
+        [[ "sS" =~ ${p_s:$i:1} ]] && return 1
+        [[ "tx" =~ ${p_s:$i:1} ]] && X+=('X') || X+=(' ')
+        [[ "tx" =~ ${p_s:$((i++)):1} ]] && let num++
       fi
       p_n+="$num"
     done

--- a/share/adapters/chmod.sh
+++ b/share/adapters/chmod.sh
@@ -20,6 +20,7 @@ chmod_calc(){
   if [[ $1 =~ ^-?[0-9]+$ && ${#1} -ge 1 && ${#1} -le 4 ]]
   then
     p_n=$(printf "%04s\n" "$1" | tr ' ' '0')
+    echo $p_n | grep -q '[8-9]' && return 1
     for (( i=0; i<${#p_n}; i++ ))
     do
       num=$(echo "obase=2;${p_n:$i:1}" | bc | xargs printf '%03d')

--- a/share/adapters/chmod.sh
+++ b/share/adapters/chmod.sh
@@ -66,19 +66,21 @@ chmod_calc(){
     for (( i=0; i<${#p_s}; i+=0 ))
     do
       num=0
+      [[ "r-" =~ ${p_s:$i:1} ]] || return 1
       [[ ${p_s:$i:1} == 'r' ]] && R+=('X') || R+=(' ')
       [[ ${p_s:$((i++)):1} == 'r' ]] && let num++
       num=$(( num << 1 ))
+      [[ "w-" =~ ${p_s:$i:1} ]] || return 1
       [[ ${p_s:$i:1} == 'w' ]] && W+=('X') || W+=(' ')
       [[ ${p_s:$((i++)):1} == 'w' ]] && let num++
       num=$(( num << 1 ))
       if [ $i -lt 6 ]
       then
-        [[ "tT" =~ ${p_s:$i:1} ]] && return 1
+        [[ "sSx-" =~ ${p_s:$i:1} ]] || return 1
         [[ "sx" =~ ${p_s:$i:1} ]] && X+=('X') || X+=(' ')
         [[ "sx" =~ ${p_s:$((i++)):1} ]] && let num++
       else
-        [[ "sS" =~ ${p_s:$i:1} ]] && return 1
+        [[ "tTx-" =~ ${p_s:$i:1} ]] || return 1
         [[ "tx" =~ ${p_s:$i:1} ]] && X+=('X') || X+=(' ')
         [[ "tx" =~ ${p_s:$((i++)):1} ]] && let num++
       fi

--- a/share/adapters/chmod.sh
+++ b/share/adapters/chmod.sh
@@ -72,12 +72,19 @@ chmod_calc(){
       [[ ${1:$i:1} == 'w' ]] && W+=('X') || W+=(' ')
       [[ ${1:$((i++)):1} == 'w' ]] && let num++
       num=$(( num << 1 ))
-      [[ 'stx' =~ ${1:$i:1} ]] && X+=('X') || X+=(' ')
-      [[ 'stx' =~ ${1:$((i++)):1} ]] && let num++
+      if [ $i -lt 6 ]
+      then
+        [[ "tT" =~ ${1:$i:1} ]] && return 1
+        [[ "sx" =~ ${1:$i:1} ]] && X+=('X') || X+=(' ')
+        [[ "sx" =~ ${1:$((i++)):1} ]] && let num++
+      else
+        [[ "sS" =~ ${1:$i:1} ]] && return 1
+        [[ "tx" =~ ${1:$i:1} ]] && X+=('X') || X+=(' ')
+        [[ "tx" =~ ${1:$((i++)):1} ]] && let num++
+      fi
       p_n+="$num"
     done
   else
-    printf "Invalid permissions string: $1"
     return 1
   fi
   # Print Final results table
@@ -95,3 +102,4 @@ Sticky bit [$sticky]\tExecute [${X[0]}]\tExecute [${X[1]}]\tExecute [${X[2]}]
 }
 
 chmod_calc $@
+[ $? -ne 0 ] && printf "Invalid permissions string: $@\n"

--- a/share/adapters/oeis.sh
+++ b/share/adapters/oeis.sh
@@ -51,7 +51,8 @@ oeis() (
   # 	. oeis <SEQ_ID>
   # 	. oeis <SEQ_ID> <LANGUAGE>
   # 	. oeis <LANGUAGE> <SEQ_ID>
-  if [ $# -lt 3 ]
+  isNum='^[0-9]+$'
+  if [ $# -lt 3 ] && [[ ${1:1} =~ $isNum || ${2:1} =~ $isNum || ${1} =~ $isNum || ${2} =~ $isNum ]] && [[ ! ${1} =~ $isNum || ! ${2} =~ $isNum ]]
   then
     # Arg-Parse ID, Generate URL
     if echo ${1^^} | grep -q '[B-Z]'
@@ -103,7 +104,7 @@ oeis() (
   # Search unknown sequence
   else
     # Build URL
-    URL+="/search?q=signed%3A$(echo $@ | grep -v [a-z] | grep -v [A-Z] | tr ' ' ',')"
+    URL+="/search?q=signed%3A$(echo $@ | tr -sc '[:digit:]' ',')"
     curl $URL 2>/dev/null > $DOC
     # Sequence IDs
     grep -o '=id:.*&' $DOC \

--- a/share/adapters/oeis.sh
+++ b/share/adapters/oeis.sh
@@ -52,15 +52,15 @@ oeis() (
   # 	. oeis <SEQ_ID> <LANGUAGE>
   # 	. oeis <LANGUAGE> <SEQ_ID>
   isNum='^[0-9]+$'
-  if [ $# -lt 3 ] && [[ ${1:1} =~ $isNum || ${2:1} =~ $isNum || ${1} =~ $isNum || ${2} =~ $isNum ]] && [[ ! ${1} =~ $isNum || ! ${2} =~ $isNum ]]
+  if [ $# -lt 3 ] && [[ ${1:1} =~ $isNum || ${2:1} =~ $isNum || ${1} =~ $isNum || ${2} =~ $isNum ]] && ! echo $1 | grep -q '[0-9]' || ! echo $2 | grep -q '[0-9]'
   then
     # Arg-Parse ID, Generate URL
     if echo ${1^^} | grep -q '[B-Z]'
     then
-      ID=$2
+      ID=${2^^}
       LANGUAGE=$1
     else
-      ID=$1
+      ID=${1^^}
       LANGUAGE=$2
     fi
     [[ ${ID:0:1} == 'A' ]] && ID=${ID:1}

--- a/share/adapters/oeis.sh
+++ b/share/adapters/oeis.sh
@@ -104,7 +104,7 @@ oeis() (
   # Search unknown sequence
   else
     # Build URL
-    URL+="/search?q=signed%3A$(echo $@ | tr -sc '[:digit:]' ',')"
+    URL+="/search?q=signed%3A$(echo $@ | tr -sc '[:digit:]-' ',')"
     curl $URL 2>/dev/null > $DOC
     # Sequence IDs
     grep -o '=id:.*&' $DOC \


### PR DESCRIPTION
## Some bugs fixed with ```chmod.sh```
1. ```--------s```, ```--------S```, ```--T------```... use to be "valid" permission strings. Now they are correctly marked as invalid.  
2. ```008```, ```888```, ```009```, ... use to be "valid" permission numbers. Now they are correctly marked as invalid.  
3. Single and double digit entries would occasionally generate false permission strings. All entries 1-4 digits are now zero padded to fix that issue.

## ```Oeis.sh``` ```cmd.py```
Still working on getting coloring for the code snippets. This arg parsing change should make the adapter more consistent. The input listed below use to break the adapter and now works perfectly:  
```oeis.sh 1,-1,1,-1,1```, ```oeis.sh 7 11```, ```oeis.sh 1```,  ```oeis.sh 1,2,3 11```  ```oeis.sh a2 python```

### TODO
- ```chmod.sh``` bits turned on marked with an ```X``` should have a different color
- ```oeis.sh``` coloring code snippets