### PR TITLE
Bug fixes and formatting

### DIFF
--- a/share/adapters/oeis.sh
+++ b/share/adapters/oeis.sh
@@ -68,12 +68,6 @@ oeis() (
     ID="A$(printf '%06d' ${ID})"
     URL+="/${ID}"
     curl $URL 2>/dev/null > $DOC
-    # Print ID, description, and sequence
-    printf "ID: ${ID}\n"
-    get_desc
-    printf "\n"
-    get_seq ${MAX_TERMS}
-    printf "\n"
     # Print Code Sample
     if [[ ${LANGUAGE^^} == ':LIST' ]]
     then
@@ -86,7 +80,16 @@ oeis() (
         | tr -d '()' \
         | sort -u >> $TMP/list
       [ $(wc -c < $TMP/list) -ne 0 ] && cat ${TMP}/list || printf "No code snippets available.\n"
-    elif [ $# -gt 1 ]
+      cat $TMP/list
+      return 0
+    fi
+    # Print ID, description, and sequence
+    printf "ID: ${ID}\n"
+    get_desc
+    printf "\n"
+    get_seq ${MAX_TERMS}
+    printf "\n"
+    if [ $# -gt 1 ]
     then
       if [[ ${LANGUAGE^^} == 'MAPLE' ]] && grep -q 'MAPLE' $DOC
       then

--- a/share/adapters/oeis.sh
+++ b/share/adapters/oeis.sh
@@ -155,7 +155,7 @@ oeis() (
   fi
   grep 'results, too many to show. Please refine your search.' /tmp/oeis/doc.html | sed -e 's/<[^>]*>//g; s/^[ \t]*//'
   # Print URL for user
-  printf "\n[${URL}]\n"
+  printf "\n[${URL}]\n" | rev | sed 's/,//' | rev
 )
 
 oeis $@

--- a/share/adapters/oeis.sh
+++ b/share/adapters/oeis.sh
@@ -148,8 +148,7 @@ oeis() (
     for i in ${!ID[@]}
     do
       printf "${ID[$i]}: ${DESC[$i]}\n"
-      echo ${SEQ[$i]}
-      printf '\n'
+      printf "${SEQ[$i]}\n\n"
     done
   fi
   grep 'results, too many to show. Please refine your search.' /tmp/oeis/doc.html | sed -e 's/<[^>]*>//g; s/^[ \t]*//'

--- a/share/adapters/oeis.sh
+++ b/share/adapters/oeis.sh
@@ -112,11 +112,7 @@ oeis() (
           > ${TMP}/prog
         # Print out code sample for specified language
         rm -f ${TMP}/code_snippet
-        awk -v tgt="${LANGUAGE^^}" -F'[()]' '/^\(/{f=(tgt==$2)} f' ${TMP}/prog > ${TMP}/code_snippet
-        L="${LANGUAGE:0:1}"
-        LANGUAGE="${LANGUAGE:1}"
-        LANGUAGE="${L^^}${LANGUAGE,,}"
-        [ $(wc -c < $TMP/code_snippet) -eq 0 ] && awk -v tgt="${LANGUAGE}" -F'[()]' '/^\(/{f=(tgt==$2)} f' ${TMP}/prog > ${TMP}/code_snippet
+        awk -v tgt="${LANGUAGE^^}" -F'[()]' '/^\(/{f=(tgt==toupper($2))} f' ${TMP}/prog > ${TMP}/code_snippet
       fi
       # Print code snippet with 4-space indent to enable colorization
       if [ $(wc -c < $TMP/code_snippet) -ne 0 ]

--- a/share/adapters/oeis.sh
+++ b/share/adapters/oeis.sh
@@ -153,6 +153,7 @@ oeis() (
       printf "\n"
     done
   fi
+  grep 'results, too many to show. Please refine your search.' /tmp/oeis/doc.html | sed -e 's/<[^>]*>//g; s/^[ \t]*//'
   # Print URL for user
   printf "\n[${URL}]\n"
 )

--- a/share/adapters/oeis.sh
+++ b/share/adapters/oeis.sh
@@ -72,23 +72,22 @@ oeis() (
     if [[ ${LANGUAGE^^} == ':LIST' ]]
     then
       rm -f ${TMP}/list
-      grep -q 'MAPLE' $DOC && printf "maple\n" >> $TMP/list
-      grep -q 'MATHEMATICA' $DOC && printf "mathematica\n" >> $TMP/list
-      parse_code "PROG.*CROSSREFS" \
+      grep -q 'MAPLE' $DOC && printf 'maple\n' >> $TMP/list
+      grep -q 'MATHEMATICA' $DOC && printf 'mathematica\n' >> $TMP/list
+      parse_code 'PROG.*CROSSREFS' \
         | grep -o '^(.*)' \
         | sed 's/ .*//g' \
         | tr -d '()' \
         | sort -u >> $TMP/list
-      [ $(wc -c < $TMP/list) -ne 0 ] && cat ${TMP}/list || printf "No code snippets available.\n"
-      cat $TMP/list
+      [ $(wc -c < $TMP/list) -ne 0 ] && cat ${TMP}/list || printf 'No code snippets available.\n'
       return 0
     fi
     # Print ID, description, and sequence
     printf "ID: ${ID}\n"
     get_desc
-    printf "\n"
+    printf '\n'
     get_seq ${MAX_TERMS}
-    printf "\n"
+    printf '\n'
     if [ $# -gt 1 ]
     then
       if [[ ${LANGUAGE^^} == 'MAPLE' ]] && grep -q 'MAPLE' $DOC
@@ -108,7 +107,7 @@ oeis() (
           > ${TMP}/code_snippet
       else
         # PROG section contains more code samples (Non Mathematica or Maple)
-        parse_code "PROG.*CROSSREFS" \
+        parse_code 'PROG.*CROSSREFS' \
           | sed '/PROG/d; /CROSSREFS/d' \
           > ${TMP}/prog
         # Print out code sample for specified language
@@ -150,7 +149,7 @@ oeis() (
     do
       printf "${ID[$i]}: ${DESC[$i]}\n"
       echo ${SEQ[$i]}
-      printf "\n"
+      printf '\n'
     done
   fi
   grep 'results, too many to show. Please refine your search.' /tmp/oeis/doc.html | sed -e 's/<[^>]*>//g; s/^[ \t]*//'

--- a/share/adapters/oeis.sh
+++ b/share/adapters/oeis.sh
@@ -151,7 +151,7 @@ oeis() (
     done
   fi
   # Print URL for user
-  printf "\nLink to source: ${URL}\n"
+  printf "\n[${URL}]\n"
 )
 
 oeis $@

--- a/share/adapters/oeis.sh
+++ b/share/adapters/oeis.sh
@@ -122,7 +122,7 @@ oeis() (
         printf "${LANGUAGE}"
         cat ${TMP}/code_snippet \
           | sed "s/(${LANGUAGE^^})/\n/; s/(${LANGUAGE})/\n/;" \
-          | sed 's/^/    /'
+          | sed 's/^/   /'
       else
         printf "${LANGUAGE^^} unavailable. Use :list to view available languages.\n"
       fi


### PR DESCRIPTION
- [x] cleaner link to source  
- [x] code snippet from 4 -> 3 space indent  
- [x] ```:list``` output is now only the list of languages (no additional sequence info)  
- [x] When provided digits generate too many results user is prompted to refine search  
- [x] Additional last comma removed from URL  
- [x] Case insensitive language search. BUG FIXED (was not able to read MuPAD snippets)  
- [x] code cleanup/consistency:
- - ```"``` when using variables and ```'``` for everything else
- - ```echo``` for conditions, ```printf``` for printing to the screen