### PR TITLE
Single letter permission changes (chmod +x)

### DIFF
--- a/share/adapters/chmod.sh
+++ b/share/adapters/chmod.sh
@@ -54,39 +54,93 @@ chmod_calc(){
       fi
     done
   # If permission string is given -> calc number
-  elif [[ ${#1} -eq 9 && $1 =~ ^[r,s,S,t,T,w,x,-]+$ ]]
+  elif [[ $1 =~ ^[r,s,S,t,T,w,x,-]+$ ]]
   then
-    p_s=$1
-    num=0
-    # Process specials
-    [[ 'sS' =~ ${p_s:2:1} ]] && setuid='X' && num=$((num+4))
-    [[ 'sS' =~ ${p_s:5:1} ]] && setgid='X' && num=$((num+2))
-    [[ 'tT' =~ ${p_s:8:1} ]] && sticky='X' && num=$((num+1))
-    [ ${num} -gt 0 ] && p_n+="$num"
-    # Calculate rest of p_n number while populating arrays for table
-    for (( i=0; i<${#p_s}; i+=0 ))
-    do
+    # FULL STRING
+    if [[ ${#1} -eq 9 ]]
+    then
+      p_s=$1
       num=0
-      [[ "r-" =~ ${p_s:$i:1} ]] || return 1
-      [[ ${p_s:$i:1} == 'r' ]] && R+=('X') || R+=(' ')
-      [[ ${p_s:$((i++)):1} == 'r' ]] && let num++
-      num=$(( num << 1 ))
-      [[ "w-" =~ ${p_s:$i:1} ]] || return 1
-      [[ ${p_s:$i:1} == 'w' ]] && W+=('X') || W+=(' ')
-      [[ ${p_s:$((i++)):1} == 'w' ]] && let num++
-      num=$(( num << 1 ))
-      if [ $i -lt 6 ]
+      # Process specials
+      [[ 'sS' =~ ${p_s:2:1} ]] && setuid='X' && num=$((num+4))
+      [[ 'sS' =~ ${p_s:5:1} ]] && setgid='X' && num=$((num+2))
+      [[ 'tT' =~ ${p_s:8:1} ]] && sticky='X' && num=$((num+1))
+      [ ${num} -gt 0 ] && p_n+="$num"
+      # Calculate rest of p_n number while populating arrays for table
+      for (( i=0; i<${#p_s}; i+=0 ))
+      do
+        num=0
+        [[ "r-" =~ ${p_s:$i:1} ]] || return 1
+        [[ ${p_s:$i:1} == 'r' ]] && R+=('X') || R+=(' ')
+        [[ ${p_s:$((i++)):1} == 'r' ]] && let num++
+        num=$(( num << 1 ))
+        [[ "w-" =~ ${p_s:$i:1} ]] || return 1
+        [[ ${p_s:$i:1} == 'w' ]] && W+=('X') || W+=(' ')
+        [[ ${p_s:$((i++)):1} == 'w' ]] && let num++
+        num=$(( num << 1 ))
+        if [ $i -lt 6 ]
+        then
+          [[ "sSx-" =~ ${p_s:$i:1} ]] || return 1
+          [[ "sx" =~ ${p_s:$i:1} ]] && X+=('X') || X+=(' ')
+          [[ "sx" =~ ${p_s:$((i++)):1} ]] && let num++
+        else
+          [[ "tTx-" =~ ${p_s:$i:1} ]] || return 1
+          [[ "tx" =~ ${p_s:$i:1} ]] && X+=('X') || X+=(' ')
+          [[ "tx" =~ ${p_s:$((i++)):1} ]] && let num++
+        fi
+        p_n+="$num"
+      done
+    # PARTIAL STRING
+    elif [[ $1 =~ ^[r,s,t,w,x]+$ ]]
+    then
+      p_s='---------'
+      p_n0=0
+      p_n1=0
+      p_n2=0
+      p_n3=0
+      R=(' ' ' ' ' ')
+      W=(' ' ' ' ' ')
+      X=(' ' ' ' ' ')
+      if [[ $1 =~ 'r' ]]
       then
-        [[ "sSx-" =~ ${p_s:$i:1} ]] || return 1
-        [[ "sx" =~ ${p_s:$i:1} ]] && X+=('X') || X+=(' ')
-        [[ "sx" =~ ${p_s:$((i++)):1} ]] && let num++
-      else
-        [[ "tTx-" =~ ${p_s:$i:1} ]] || return 1
-        [[ "tx" =~ ${p_s:$i:1} ]] && X+=('X') || X+=(' ')
-        [[ "tx" =~ ${p_s:$((i++)):1} ]] && let num++
+        p_s=$(echo $p_s | sed 's/./r/1; s/./r/4; s/./r/7;')
+        let p_n1+=4
+        let p_n2+=4
+        let p_n3+=4
+        R=('X' 'X' 'X')
       fi
-      p_n+="$num"
-    done
+      if [[ $1 =~ 'w' ]]
+      then
+        p_s=$(echo $p_s | sed 's/./w/2')
+        let p_n1+=2
+        W=('X' ' ' ' ')
+      fi
+      if [[ $1 =~ 'x' ]]
+      then
+        p_s=$(echo $p_s | sed 's/./x/3; s/./x/6; s/./x/9;')
+        let p_n1+=1
+        let p_n2+=1
+        let p_n3+=1
+        X=('X' 'X' 'X')
+      fi
+      if [[ $1 =~ 's' ]]
+      then
+        [[ ${p_s:2:1} == 'x' ]] && p_s=$(echo $p_s | sed 's/./s/3') || p_s=$(echo $p_s | sed 's/./S/3')
+        [[ ${p_s:5:1} == 'x' ]] && p_s=$(echo $p_s | sed 's/./s/6') || p_s=$(echo $p_s | sed 's/./S/6')
+        let p_n0+=6
+        setuid='X'
+        setgid='X'
+      fi
+      if [[ $1 =~ 't' ]]
+      then
+        let p_n0+=1
+        [[ ${p_s:8:1} == 'x' ]] && p_s=$(echo $p_s | sed 's/./t/9') || p_s=$(echo $p_s | sed 's/./T/9')
+        sticky='X'
+      fi
+      p_n="${p_n0}${p_n1}${p_n2}${p_n3}"
+    else
+      return 1
+    fi
   else
     return 1
   fi


### PR DESCRIPTION
Previously chmod.sh only accepted strings of length 9 to convert to an equivalent permission number.
Now shorter strings are accepted for use cases such as:
- ```chmod +x```
- ```chmod +sx``` 
- etc ...