### PR TITLE
Update Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,4 @@ language:
 before_install:
   - docker-compose up -d
   - docker ps
+  - docker images

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,8 @@
-dist: trusty
-sudo: required
+dist: bionic
 
 language:
   - generic
 
-services:
-  - docker
-
-env:
-  DOCKER_COMPOSE_VERSION: 1.22.0
-
-addons:
-  apt:
-    packages:
-      - docker-ce
-
 before_install:
-  - sudo rm /usr/local/bin/docker-compose
-  - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
-  - chmod +x docker-compose
-  - sudo mv docker-compose /usr/local/bin
   - docker-compose up -d
   - docker ps


### PR DESCRIPTION
When reenabled [the Travis status](https://travis-ci.org/github/chubin/cheat.sh) should now be green again.

The image that is built on Travis is reported to be 276 MB.
https://travis-ci.com/github/abitrolly/cheat.sh/builds/177627315#L386

Now need to find a way to run tests with it.