### PR TITLE
Posix sh

### DIFF
--- a/share/cht.sh.txt
+++ b/share/cht.sh.txt
@@ -58,9 +58,17 @@ esac
 if ! local foo 2>/dev/null; then
   if typeset foo 2>/dev/null; then
     alias local=typeset
+  elif declare foo 2>/dev/null; then
+    alias local=declare
   else
     alias local=eval		# XXX avoid "local foo", use "local foo=" instead
   fi
+fi
+unset foo
+
+# for zsh
+if [ -n "$ZSH_NAME" ]; then
+  set -o shwordsplit
 fi
 
 fatal()

--- a/share/cht.sh.txt
+++ b/share/cht.sh.txt
@@ -422,14 +422,14 @@ elif [ "$(uname -s)" = OpenBSD ] && [ -x /usr/bin/ftp ]; then
       esac
     done
     shift $((OPTIND - 1))
-    /usr/bin/ftp "$args" "$@"
+    /usr/bin/ftp $args "$@"
   }
 else
   command -v curl   >/dev/null || { echo 'DEPENDENCY: install "curl" to use cht.sh' >&2; exit 1; }
   _CURL=$(command -v curl)
   if [ x"$CHTSH_CURL_OPTIONS" != x ]; then
     curl() {
-      $_CURL "${CHTSH_CURL_OPTIONS}" "$@"
+      $_CURL ${CHTSH_CURL_OPTIONS} "$@"
     }
   fi
 fi

--- a/share/cht.sh.txt
+++ b/share/cht.sh.txt
@@ -55,8 +55,12 @@ esac
 
 # for KSH93
 # shellcheck disable=SC2034,SC2039,SC2168
-if echo "$KSH_VERSION" | grep -q ' 93' && ! local foo 2>/dev/null; then
-  alias local=typeset
+if ! local foo 2>/dev/null; then
+  if typeset foo 2>/dev/null; then
+    alias local=typeset
+  else
+    alias local=eval		# XXX avoid "local foo", use "local foo=" instead
+  fi
 fi
 
 fatal()
@@ -77,7 +81,7 @@ cheatsh_standalone_install()
 {
   # the function installs cheat.sh with the upstream repositories
   # in the standalone mode
-  local installdir; installdir="$1"
+  local installdir="$1"
   local default_installdir="$HOME/.cheat.sh"
 
   [ -z "$installdir" ] && installdir=${default_installdir}
@@ -130,7 +134,7 @@ EOF
   [ "$_exit_code" -ne 0 ] && return "$_exit_code"
 
   while true; do
-    local _installdir
+    local _installdir=
     echo -n "Where should cheat.sh be installed [$installdir]? "; read -r _installdir
     [ -n "$_installdir" ] && installdir=$_installdir
 
@@ -158,7 +162,7 @@ EOF
   fi
 
   local space_needed=700
-  local space_available; space_available=$(($(df -k "$installdir" | awk '{print $4}' | tail -1)/1024))
+  local space_available=$(($(df -k "$installdir" | awk '{print $4}' | tail -1)/1024))
 
   if [ "$space_available" -lt "$space_needed" ]; then
     echo "ERROR: Installation directory has no enough space (needed: ${space_needed}M, available: ${space_available}M"
@@ -250,8 +254,8 @@ EOF
 
   _say_what_i_do Done
 
-  local v1; v1=$(printf "\033[0;1;32m")
-  local v2; v2=$(printf "\033[0m")
+  local v1=$(printf "\033[0;1;32m")
+  local v2=$(printf "\033[0m")
 
   cat <<EOF | sed "s/{/$v1/; s/}/$v2/"
 
@@ -290,7 +294,7 @@ chtsh_mode()
 {
   local mode="$1"
 
-  local text; text=$(
+  local text=$(
     echo "  auto    use the standalone installation first"
     echo "  lite    use the cheat sheets server directly"
   )
@@ -355,7 +359,7 @@ prepare_query()
   local input="$1"; shift
   local arguments="$1"
 
-  local query
+  local query=
   if [ -z "$section" ] || [ x"${input}" != x"${input#/}" ]; then
     query=$(printf %s "$input" | sed 's@ @/@; s@ @+@g')
   else
@@ -401,20 +405,20 @@ if [ "$CHTSH_MODE" = auto ] && [ -d "$CHEATSH_INSTALLATION" ]; then
   curl() {
     # ignoring all options
     # currently the standalone.py does not support them anyway
-    local opt
+    local opt=
     OPTIND=1
     while getopts "b:s" opt; do
       :
     done
     shift $((OPTIND - 1))
 
-    local url; url="$1"; shift
+    local ur="$1"; shift
     PYTHONIOENCODING=UTF-8 "$CHEATSH_INSTALLATION/ve/bin/python" "$CHEATSH_INSTALLATION/lib/standalone.py" "${url#"$CHTSH_URL"}" "$@"
   }
 elif [ "$(uname -s)" = OpenBSD ] && [ -x /usr/bin/ftp ]; then
   # any better test not involving either OS matching or actual query?
   curl() {
-    local opt args="-o -"
+    local opt= args="-o -"
     OPTIND=1
     while getopts "b:s" opt; do
       case $opt in

--- a/share/cht.sh.txt
+++ b/share/cht.sh.txt
@@ -402,6 +402,7 @@ if [ "$CHTSH_MODE" = auto ] && [ -d "$CHEATSH_INSTALLATION" ]; then
     # ignoring all options
     # currently the standalone.py does not support them anyway
     local opt
+    OPTIND=1
     while getopts "b:s" opt; do
       :
     done
@@ -414,6 +415,7 @@ elif [ "$(uname -s)" = OpenBSD ] && [ -x /usr/bin/ftp ]; then
   # any better test not involving either OS matching or actual query?
   curl() {
     local opt args="-o -"
+    OPTIND=1
     while getopts "b:s" opt; do
       case $opt in
         b) args="$args -c $OPTARG";;

--- a/share/cht.sh.txt
+++ b/share/cht.sh.txt
@@ -340,7 +340,7 @@ do_query()
     b_opts="-b \"\$HOME/.cht.sh/id\""
   fi
 
-  eval curl "$b_opts" -s "$uri" > "$TMP1"
+  eval curl $b_opts -s "$uri" > "$TMP1"
 
   if [ -z "$lines" ] || [ "$(wc -l "$TMP1" | awk '{print $1}')" -lt "$lines" ]; then
     cat "$TMP1"

--- a/share/cht.sh.txt
+++ b/share/cht.sh.txt
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # shellcheck disable=SC1117,SC2001
 #
 # [X] open section
@@ -122,8 +122,8 @@ EOF
 
   local _exit_code=0
 
-  local dependencies=(python git virtualenv)
-  for dep in "${dependencies[@]}"; do
+  local dependencies="python git virtualenv"
+  for dep in $dependencies; do
     command -v "$dep" >/dev/null || \
     { echo "DEPENDENCY: \"$dep\" is needed to install cheat.sh in the standalone mode" >&2; _exit_code=1; }
   done
@@ -191,15 +191,15 @@ EOF
   if [[ $PYTHON2 = YES ]]; then
     python="python2"
     pip="pip"
-    virtualenv_python3_option=()
+    virtualenv_python3_options=
   else
     python="python3"
     pip="pip3"
-    virtualenv_python3_option=(-p python3)
+    virtualenv_python3_options="-p python3"
   fi
 
   _say_what_i_do Creating virtual environment
-  "$python" "$(command -v virtualenv)" "${virtualenv_python3_option[@]}" ve \
+  "$python" "$(command -v virtualenv)" $virtualenv_python3_options ve \
       || fatal Could not create virtual environment with "python2 $(command -v virtualenv) ve"
 
   export CHEATSH_PATH_WORKDIR=$PWD
@@ -712,8 +712,7 @@ cmd_update() {
   if ! cmp "$0" "$TMP2" > /dev/null 2>&1; then
     if grep -q ^__CHTSH_VERSION= "$TMP2"; then
       # section was vaildated by us already
-      args=(--shell "$section")
-      cp "$TMP2" "$0" && echo "Updated. Restarting..." && rm "$TMP2" && CHEATSH_RESTART=1 exec "$0" "${args[@]}"
+      cp "$TMP2" "$0" && echo "Updated. Restarting..." && rm "$TMP2" && CHEATSH_RESTART=1 exec "$0" --shell "$section"
     else
       echo "Something went wrong. Please update manually"
     fi


### PR DESCRIPTION
The portability fans are back! :-)

There were a few things broken already. In particular, a few places had "$foo" instead of $foo, breaking the intended words expansion.

The bash arrays were replaced with either simple expansion, or written directly, resulting in no code quality loss.

The zsh bits are only needed if someone will ever run "zsh cht.sh" and could be dropped; when zsh is working as sh, the shwordsplit option gets set automatically.

The local/typeset/declare case is the most complicated one. Technically, POSIX just reserves "local", "typeset" and "declare" for use by shell, keeping them as undefined behavior. All the shells I've tested with (bash, dash, ksh93, OpenBSD ksh, zsh) support either "local" or "typeset" command. But for better compatibility sakeness, since it was meaningful enough for 884161c4c7a3ccf6eb4c6ed226ed1104b49614ef, the "eval" fallback was implemented. This makes "local foo" invalid, thought, so I had to replace all of them with "local foo=" instead. But the better option likely be just ignoring shells that do not support local-scoped variables, since the code is likely to break in this case anyway.