### PR TITLE
Tests tweaks

### DIFF
--- a/.github/workflows/tests-ubuntu.yml
+++ b/.github/workflows/tests-ubuntu.yml
@@ -1,0 +1,19 @@
+name: Ubuntu Tests
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: install dependencies
+      run: pip3 install -r requirements.txt
+    - name: run tests
+      run: bash tests/run-tests.sh

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -109,8 +109,4 @@ else
   echo TESTS/OK/UPDATED "$i/$((i-failed))/$failed"
 fi
 
-if [ "$failed" != 0 ]; then
-  exit 1
-else
-  exit 0
-fi
+test $failed -eq 0

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -85,7 +85,7 @@ while read -r number test_line; do
     eval "curl -s $CHTSH_URL/$test_line" > "$TMP"
   fi
 
-  if ! diff -u3 --color=always results/"$number" "$TMP" > "$TMP2"; then
+  if ! diff -u3 results/"$number" "$TMP" > "$TMP2"; then
     if [[ $update_tests_results = NO ]]; then
       if [ "$show_details" = YES ]; then
         cat "$TMP2"


### PR DESCRIPTION
1. Minor tweaks in `run-tests.sh`, in particular drop `--color=always` from `diff` command line, it doesn't work outside GNU world, and this breaks running tests on non-Linux.

2. Add preliminary GitHub action for CI. I don't know how to test it without putting in repository first, though. :( 