### PR TITLE
Use `flask run` server for debugging

### DIFF
--- a/bin/srv.py
+++ b/bin/srv.py
@@ -275,12 +275,18 @@ def answer(topic=None):
     return Response(result, mimetype='text/plain')
 
 
-if '--debug' in sys.argv:
-    app.debug = True
-if 'CHEATSH_PORT' in os.environ:
-    PORT = int(os.environ.get('CHEATSH_PORT'))
-else:
-    PORT = CONFIG['server.port']
-SRV = WSGIServer((CONFIG['server.bind'], PORT), app) # log=None)
-print("Starting server on {}:{}".format(SRV.address[0], SRV.address[1]))
-SRV.serve_forever()
+if __name__ == '__main__':
+    # Serving cheat.sh with `gevent`
+    if '--debug' in sys.argv:
+        # Not all debug mode features are available under `gevent`
+        # https://github.com/pallets/flask/issues/3825
+        app.debug = True
+
+    if 'CHEATSH_PORT' in os.environ:
+        PORT = int(os.environ.get('CHEATSH_PORT'))
+    else:
+        PORT = CONFIG['server.port']
+
+    SRV = WSGIServer((CONFIG['server.bind'], PORT), app) # log=None)
+    print("Starting gevent server on {}:{}".format(SRV.address[0], SRV.address[1]))
+    SRV.serve_forever()

--- a/docker-compose.debug.yml
+++ b/docker-compose.debug.yml
@@ -1,8 +1,21 @@
-# Compose override to add --debug option to bin/srv.py
-# call to print tracebacks on errors to stdout.
+# Compose override, see https://docs.docker.com/compose/extends/
 #
-# See https://docs.docker.com/compose/extends/
+# - Run `flask` standalone server with more debug aids instead of `gevent`
+# - Turn on Flask debug mode to print tracebacks and autoreload code
+# - Mounts fresh sources from current dir as volume
+#
+# Usage:
+#   docker-compose -f docker-compose.yml -f docker-compose.debug.yml up
+#
 version: '2'
 services:
   app:
-    command: "--debug"
+    environment:
+      FLASK_ENV: development
+      #FLASK_RUN_RELOAD: False
+      FLASK_APP: "bin/srv.py"
+      FLASK_RUN_HOST: 0.0.0.0
+      FLASK_RUN_PORT: 8002
+    entrypoint: ["/usr/bin/flask", "run"]
+    volumes:
+      - .:/app:Z


### PR DESCRIPTION
Because at least live reloading doesn't seem to work with `gevent`.