### PR TITLE
Update `polyglot` and use Ubuntu 20.04 for Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,13 @@
-FROM alpine:3.12
-# fetching cheat sheets
-## installing dependencies
-RUN apk add --update --no-cache git py3-six py3-pygments py3-yaml py3-gevent \
-      libstdc++ py3-colorama py3-requests py3-icu py3-redis
-## building missing python packages
-RUN apk add --no-cache --virtual build-deps py3-pip g++ python3-dev \
-    && pip3 install --no-cache-dir rapidfuzz colored polyglot pycld2 \
-    && apk del build-deps
-## copying
+FROM ubuntu:20.04
+
+### copying app sources
 WORKDIR /app
 COPY . /app
-RUN mkdir -p /root/.cheat.sh/log/ \
-    && python3 lib/fetch.py fetch-all
 
-# installing server dependencies
-RUN apk add --update --no-cache py3-jinja2 py3-flask bash gawk
+RUN pip install --upgrade -r requirements.txt
+
+## fetching cheat sheets
+RUN python3 lib/fetch.py fetch-all
+
 ENTRYPOINT ["python3", "-u", "bin/srv.py"]
 CMD [""]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM ubuntu:20.04
+FROM python:3.9-slim
 
 ### copying app sources
 WORKDIR /app
 COPY . /app
 
-RUN pip install --upgrade -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 
 ## fetching cheat sheets
 RUN python3 lib/fetch.py fetch-all

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim
+FROM python:3.9
 
 ### copying app sources
 WORKDIR /app

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ redis
 colored
 langdetect
 cffi
-git+https://github.com/aboSamoor/polyglot.git@9b93b2e
+https://github.com/aboSamoor/polyglot/archive/9b93b2e.zip
 colorama
 pyyaml
 python-Levenshtein

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,6 @@ langdetect
 cffi
 polyglot
 PyICU
-pycld2
 colorama
 pyyaml
 python-Levenshtein

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,8 +9,7 @@ redis
 colored
 langdetect
 cffi
-polyglot
-PyICU
+git+https://github.com/aboSamoor/polyglot.git@9b93b2e
 colorama
 pyyaml
 python-Levenshtein


### PR DESCRIPTION
`pycdl2` package is not packaged in Alpine, and needs to be rebuilt from C code every time. I decided to look for replacement and could not find where it is used at all.

It is added together with `PyICU` in https://github.com/chubin/cheat.sh/commit/877da9c2201d6daaaf6319f5f8a889c8b29a522c although not clear why.