### PR TITLE
Remove explicit `gevent` imports

### DIFF
--- a/lib/adapter/cmd.py
+++ b/lib/adapter/cmd.py
@@ -1,15 +1,14 @@
 """
 """
 
-# pylint: disable=relative-import,wrong-import-position,unused-argument,abstract-method
-
-from gevent.monkey import patch_all
-from gevent.subprocess import Popen, PIPE
-
-from .adapter import Adapter
+# pylint: disable=unused-argument,abstract-method
 
 import os.path
 import re
+from subprocess import Popen, PIPE
+
+from .adapter import Adapter
+
 
 def _get_abspath(path):
     """Find absolute path of the specified `path`

--- a/lib/adapter/question.py
+++ b/lib/adapter/question.py
@@ -4,15 +4,13 @@ Configuration parameters:
     path.internal.bin.upstream
 """
 
-# pylint: disable=relative-import,wrong-import-position,wrong-import-order
+# pylint: disable=relative-import
 
 from __future__ import print_function
 
-from gevent.monkey import patch_all
-from gevent.subprocess import Popen, PIPE
-
 import os
 import re
+from subprocess import Popen, PIPE
 
 from polyglot.detect import Detector
 from polyglot.detect.base import UnknownLanguage

--- a/lib/fmt/comments.py
+++ b/lib/fmt/comments.py
@@ -18,12 +18,7 @@ Exported functions:
 Configuration parameters:
 """
 
-# pylint: disable=wrong-import-position,wrong-import-order
-
 from __future__ import print_function
-
-from gevent.monkey import patch_all
-from gevent.subprocess import Popen
 
 import sys
 import os
@@ -31,6 +26,7 @@ import textwrap
 import hashlib
 import re
 from itertools import groupby, chain
+from subprocess import Popen
 from tempfile import NamedTemporaryFile
 
 from config import CONFIG

--- a/lib/frontend/html.py
+++ b/lib/frontend/html.py
@@ -5,22 +5,19 @@ Configuration parameters:
     path.internal.ansi2html
 """
 
-from gevent.monkey import patch_all
-from gevent.subprocess import Popen, PIPE
-
-# pylint: disable=wrong-import-position,wrong-import-order
 import sys
 import os
 import re
+from subprocess import Popen, PIPE
 
 MYDIR = os.path.abspath(os.path.join(__file__, '..', '..'))
 sys.path.append("%s/lib/" % MYDIR)
 
+# pylint: disable=wrong-import-position
 from config import CONFIG
 from globals import error
 from buttons import TWITTER_BUTTON, GITHUB_BUTTON, GITHUB_BUTTON_FOOTER
 import frontend.ansi
-# pylint: disable=wrong-import-position,wrong-import-order
 
 # temporary having it here, but actually we have the same data
 # in the adapter module


### PR DESCRIPTION
It is enough to monkey patch one time at the top level, which is done in `bin/srv.py` web server script.