### PR TITLE
Add OpenSearch description format file

### DIFF
--- a/share/ansi2html.sh
+++ b/share/ansi2html.sh
@@ -103,6 +103,7 @@ fi
 printf '%s' "<html>
 <head>
 <meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\"/>
+<link rel=\"search\" type=\"application/opensearchdescription+xml\" href=\"/files/opensearch.xml\" title=\"cheat.sh\" />
 <link rel=\"stylesheet\" type=\"text/css\" href=\"/files/style.css\" />
 <link rel=\"stylesheet\" type=\"text/css\" href=\"/files/fonts/stylesheet.css\" />
 <style type=\"text/css\">

--- a/share/static/opensearch.xml
+++ b/share/static/opensearch.xml
@@ -2,7 +2,7 @@
 <OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/" xmlns:moz="http://www.mozilla.org/2006/browser/search/">
 <ShortName>cheat.sh</ShortName>
 <Description>The only cheat sheet you need. Unified access to the best community driven documentation repositories of the world.</Description>
-<Url type="text/html" template="https://cheat.sh/?topic={searchTerms}" />
+<Url type="text/html" template="https://cheat.sh/{searchTerms}" />
 <Url type="application/opensearchdescription+xml" rel="self" template="https://cheat.sh/files/opensearch.xml" />
 <Tags>cheatsheet curl terminal command-line cli examples documentation help tldr</Tags>
 <Language>en-US</Language>

--- a/share/static/opensearch.xml
+++ b/share/static/opensearch.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/" xmlns:moz="http://www.mozilla.org/2006/browser/search/">
+<ShortName>cheat.sh</ShortName>
+<Description>The only cheat sheet you need. Unified access to the best community driven documentation repositories of the world.</Description>
+<Url type="text/html" template="https://cheat.sh/?topic={searchTerms}" />
+<Url type="application/opensearchdescription+xml" rel="self" template="https://cheat.sh/files/opensearch.xml" />
+<Tags>cheatsheet curl terminal command-line cli examples documentation help tldr</Tags>
+<Language>en-US</Language>
+<moz:SearchForm>https://cheat.sh</moz:SearchForm>
+</OpenSearchDescription>


### PR DESCRIPTION
Adds support for OpenSearch, which essentially means that Firefox users can add cheat.sh as a search engine, but also that other services will be able to easier discover cheat.sh's search capabilities.

See [the opensearch documentation](https://github.com/dewitt/opensearch) and [MDN](https://developer.mozilla.org/en-US/docs/Web/OpenSearch) for more info.