### PR TITLE
Show non-printable chars in failed tests

### DIFF
--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -88,7 +88,7 @@ while read -r number test_line; do
   if ! diff -u3 results/"$number" "$TMP" > "$TMP2"; then
     if [[ $update_tests_results = NO ]]; then
       if [ "$show_details" = YES ]; then
-        cat "$TMP2"
+        cat -t "$TMP2"
       fi
       echo "FAILED: [$number] $test_line"
     else


### PR DESCRIPTION
Using this advice - https://unix.stackexchange.com/questions/45711/diff-reports-two-files-differ-although-they-are-the-same/103712#103712

```
  -t                       equivalent to -vT
  -T, --show-tabs          display TAB characters as ^I
  -v, --show-nonprinting   use ^ and M- notation, except for LFD and TAB
```