### PR TITLE
Fix some unescaped shell colors

### DIFF
--- a/share/cht.sh.txt
+++ b/share/cht.sh.txt
@@ -692,7 +692,7 @@ cmd_stealth() {
       past=$current
       current_text="$(echo $current | tr -c '[a-zA-Z0-9]' ' ')"
       if [ "$(echo "$current_text" | wc -w)" -gt "$STEALTH_MAX_SELECTION_LENGTH" ]; then
-        echo "\033[0;31mstealth:\033[0m selection length is longer than $STEALTH_MAX_SELECTION_LENGTH words; ignoring"
+        printf "\033[0;31mstealth:\033[0m selection length is longer than $STEALTH_MAX_SELECTION_LENGTH words; ignoring\n"
         continue
       else
         printf "\n\033[0;31mstealth: \033[7m $current_text\033[0m\n"

--- a/tests/results/8
+++ b/tests/results/8
@@ -692,7 +692,7 @@ cmd_stealth() {
       past=$current
       current_text="$(echo $current | tr -c '[a-zA-Z0-9]' ' ')"
       if [ "$(echo "$current_text" | wc -w)" -gt "$STEALTH_MAX_SELECTION_LENGTH" ]; then
-        echo "\033[0;31mstealth:\033[0m selection length is longer than $STEALTH_MAX_SELECTION_LENGTH words; ignoring"
+        printf "\033[0;31mstealth:\033[0m selection length is longer than $STEALTH_MAX_SELECTION_LENGTH words; ignoring\n"
         continue
       else
         printf "\n\033[0;31mstealth: \033[7m $current_text\033[0m\n"


### PR DESCRIPTION
### Changes
* Uses printf rather than echo to escape shell colors.

### Examples

Before:
![image](https://user-images.githubusercontent.com/26678747/105424891-38634d80-5c16-11eb-806e-c8a9c640566e.png)

After:
![image](https://user-images.githubusercontent.com/26678747/105425338-2e8e1a00-5c17-11eb-94c4-6d6422353c65.png)

### Notes

I couldn't find any more cases of this mistake:
```console
$ egrep -rnw . --exclude-dir=venv -e "echo.*033.*"
./tests/results/8:695:        echo "\033[0;31mstealth:\033[0m selection length is longer than $STEALTH_MAX_SELECTION_LENGTH words; ignoring"
./share/cht.sh.txt:695:        echo "\033[0;31mstealth:\033[0m selection length is longer than $STEALTH_MAX_SELECTION_LENGTH words; ignoring"
```
