### PR TITLE
Add aiohttp as a plain text agent

### DIFF
--- a/bin/app.py
+++ b/bin/app.py
@@ -82,6 +82,7 @@ PLAIN_TEXT_AGENTS = [
     "openbsd ftp",
     "powershell",
     "fetch",
+    "aiohttp",
 ]
 
 def _is_html_needed(user_agent):


### PR DESCRIPTION
In python an `aiohttp.ClientSession()` defaults with the user agent `Python/{python_verions_here} aiohttp/{aiohttp_version_here}`.
By adding `aiohttp` to the list of plain text user agents, an aiohttp session will behave the same as a requests session.