### PR TITLE
Help text: remove outdated information, fix spelling

### DIFF
--- a/share/help.txt
+++ b/share/help.txt
@@ -1,7 +1,7 @@
 Usage:
-    
-    $ curl cheat.sh/TOPIC       show cheat sheet on the TOPIC      
-    $ curl cheat.sh/TOPIC/SUB   show cheat sheet on the SUB topic in TOPIC      
+
+    $ curl cheat.sh/TOPIC       show cheat sheet on the TOPIC
+    $ curl cheat.sh/TOPIC/SUB   show cheat sheet on the SUB topic in TOPIC
     $ curl cheat.sh/~KEYWORD    search cheat sheets for KEYWORD
 
 Options:
@@ -19,7 +19,7 @@ Options:
 Options can be combined together in this way:
 
     curl 'cheat.sh/for?qT&style=bw'
-    
+
 (when using & in shell, don't forget to specify the quotes or escape & with \)
 
 Special pages:
@@ -54,7 +54,7 @@ Editor integration:
 
 Search:
 
-    /~snapshot          look for "snapshot" in the first level cheat sheets 
+    /~snapshot          look for "snapshot" in the first level cheat sheets
     /~ssh~passphrase    several keywords can be combined together using ~
     /scala/~closure     look for "closure" in scala cheat sheets
     /~snapshot/r        look for "snapshot" in all cheat sheets recursively
@@ -71,17 +71,9 @@ List of search options:
 
 Programming languages topics:
 
-each programming language topic has the following subptopics:
+Each programming language topic has the following subtopics:
 
     hello               hello world + how to start the program
     :learn              big cheat sheet for learning language from scratch
-    :list               list of topics        
+    :list               list of topics
     :random             fetches a random cheat sheet belonging to the topic
-
-Support programming languages:
-
-    go 
-    scala
-    rust
-    python
-    php

--- a/tests/results/7
+++ b/tests/results/7
@@ -1,7 +1,7 @@
 Usage:
-    
-    $ curl cheat.sh/TOPIC       show cheat sheet on the TOPIC      
-    $ curl cheat.sh/TOPIC/SUB   show cheat sheet on the SUB topic in TOPIC      
+
+    $ curl cheat.sh/TOPIC       show cheat sheet on the TOPIC
+    $ curl cheat.sh/TOPIC/SUB   show cheat sheet on the SUB topic in TOPIC
     $ curl cheat.sh/~KEYWORD    search cheat sheets for KEYWORD
 
 Options:
@@ -19,7 +19,7 @@ Options:
 Options can be combined together in this way:
 
     curl 'cheat.sh/for?qT&style=bw'
-    
+
 (when using & in shell, don't forget to specify the quotes or escape & with \)
 
 Special pages:
@@ -54,7 +54,7 @@ Editor integration:
 
 Search:
 
-    /~snapshot          look for "snapshot" in the first level cheat sheets 
+    /~snapshot          look for "snapshot" in the first level cheat sheets
     /~ssh~passphrase    several keywords can be combined together using ~
     /scala/~closure     look for "closure" in scala cheat sheets
     /~snapshot/r        look for "snapshot" in all cheat sheets recursively
@@ -71,17 +71,9 @@ List of search options:
 
 Programming languages topics:
 
-each programming language topic has the following subptopics:
+Each programming language topic has the following subtopics:
 
     hello               hello world + how to start the program
     :learn              big cheat sheet for learning language from scratch
-    :list               list of topics        
+    :list               list of topics
     :random             fetches a random cheat sheet belonging to the topic
-
-Support programming languages:
-
-    go 
-    scala
-    rust
-    python
-    php


### PR DESCRIPTION
The current help text (`cheat.sh/:help`) states that the supported programming languages are Go, Scala, Rust, Python, and PHP. This is a bit misleading as many more are supported, such as Haskell and Ruby. I think it's best to remove this paragraph, instead of exhaustively listing supported programming languages, as the list can easily become outdated and can already be found via `cheat.sh/:list`, but of course opinions are welcome.

Also fixes a capitalisation and spelling mistake.