### PR TITLE
Add Wayland support

### DIFF
--- a/share/cht.sh.txt
+++ b/share/cht.sh.txt
@@ -514,7 +514,11 @@ else
 fi
 
 if [ "$is_macos" != yes ]; then
-  command -v xsel >/dev/null ||   echo 'DEPENDENCY: please install "xsel" for "copy"' >&2
+  if [ "$XDG_SESSION_TYPE" = wayland ]; then
+    command -v wl-copy >/dev/null || echo 'DEPENDENCY: please install "wl-copy" for "copy"' >&2
+  else
+    command -v xsel >/dev/null ||   echo 'DEPENDENCY: please install "xsel" for "copy"' >&2
+  fi
 fi
 command -v rlwrap >/dev/null || { echo 'DEPENDENCY: install "rlwrap" to use cht.sh in the shell mode' >&2; exit 1; }
 
@@ -562,7 +566,11 @@ cmd_copy() {
   else
     curl -s "${CHTSH_URL}"/"$(get_query_options "$query"?T)" > "$TMP1"
     if [ "$is_macos" != yes ]; then
-      xsel -bi < "$TMP1"
+      if [ "$XDG_SESSION_TYPE" = wayland ]; then
+        wl-copy < "$TMP1"
+      else
+        xsel -bi < "$TMP1"
+      fi
     else
       pbcopy < "$TMP1"
     fi
@@ -578,7 +586,11 @@ cmd_ccopy() {
   else
     curl -s "${CHTSH_URL}"/"$(get_query_options "$query"?TQ)" > "$TMP1"
     if [ "$is_macos" != yes ]; then
-      xsel -bi < "$TMP1"
+      if [ "$XDG_SESSION_TYPE" = wayland ]; then
+        wl-copy < "$TMP1"
+      else
+        xsel -bi < "$TMP1"
+      fi
     else
       pbcopy < "$TMP1"
     fi

--- a/share/cht.sh.txt
+++ b/share/cht.sh.txt
@@ -686,7 +686,11 @@ cmd_stealth() {
   if [ "$is_macos" = yes ]; then
     past=$(pbpaste)
   else
-    past=$(xsel -o)
+    if [ "$XDG_SESSION_TYPE" = wayland ]; then
+      past=$(xl-paste -p)
+    else
+      past=$(xsel -o)
+    fi
   fi
   printf "\033[0;31mstealth:\033[0m you are in the stealth mode; select any text in any window for a query\n"
   printf "\033[0;31mstealth:\033[0m selections longer than $STEALTH_MAX_SELECTION_LENGTH words are ignored\n"
@@ -698,7 +702,11 @@ cmd_stealth() {
     if [ "$is_macos" = yes ]; then
       current=$(pbpaste)
     else
-      current=$(xsel -o)
+      if [ "$XDG_SESSION_TYPE" = wayland ]; then
+        current=$(wl-paste -p)
+      else
+        current=$(xsel -o)
+      fi
     fi
     if [ "$past" != "$current" ]; then
       past=$current

--- a/share/cht.sh.txt
+++ b/share/cht.sh.txt
@@ -24,8 +24,8 @@
 # count words in text counter
 # group elements list
 
-__CHTSH_VERSION=0.0.2
-__CHTSH_DATETIME="2021-04-23 09:30:30 +0200"
+__CHTSH_VERSION=0.0.3
+__CHTSH_DATETIME="2021-04-25 09:30:30 +0200"
 
 # cht.sh configuration loading
 #

--- a/share/cht.sh.txt
+++ b/share/cht.sh.txt
@@ -687,7 +687,7 @@ cmd_stealth() {
     past=$(pbpaste)
   else
     if [ "$XDG_SESSION_TYPE" = wayland ]; then
-      past=$(xl-paste -p)
+      past=$(wl-paste -p)
     else
       past=$(xsel -o)
     fi

--- a/tests/results/8
+++ b/tests/results/8
@@ -24,8 +24,8 @@
 # count words in text counter
 # group elements list
 
-__CHTSH_VERSION=0.0.2
-__CHTSH_DATETIME="2021-04-23 09:30:30 +0200"
+__CHTSH_VERSION=0.0.3
+__CHTSH_DATETIME="2021-04-25 09:30:30 +0200"
 
 # cht.sh configuration loading
 #
@@ -514,7 +514,11 @@ else
 fi
 
 if [ "$is_macos" != yes ]; then
-  command -v xsel >/dev/null ||   echo 'DEPENDENCY: please install "xsel" for "copy"' >&2
+  if [ "$XDG_SESSION_TYPE" = wayland ]; then
+    command -v wl-copy >/dev/null || echo 'DEPENDENCY: please install "wl-copy" for "copy"' >&2
+  else
+    command -v xsel >/dev/null ||   echo 'DEPENDENCY: please install "xsel" for "copy"' >&2
+  fi
 fi
 command -v rlwrap >/dev/null || { echo 'DEPENDENCY: install "rlwrap" to use cht.sh in the shell mode' >&2; exit 1; }
 
@@ -562,7 +566,11 @@ cmd_copy() {
   else
     curl -s "${CHTSH_URL}"/"$(get_query_options "$query"?T)" > "$TMP1"
     if [ "$is_macos" != yes ]; then
-      xsel -bi < "$TMP1"
+      if [ "$XDG_SESSION_TYPE" = wayland ]; then
+        wl-copy < "$TMP1"
+      else
+        xsel -bi < "$TMP1"
+      fi
     else
       pbcopy < "$TMP1"
     fi
@@ -578,7 +586,11 @@ cmd_ccopy() {
   else
     curl -s "${CHTSH_URL}"/"$(get_query_options "$query"?TQ)" > "$TMP1"
     if [ "$is_macos" != yes ]; then
-      xsel -bi < "$TMP1"
+      if [ "$XDG_SESSION_TYPE" = wayland ]; then
+        wl-copy < "$TMP1"
+      else
+        xsel -bi < "$TMP1"
+      fi
     else
       pbcopy < "$TMP1"
     fi
@@ -674,7 +686,11 @@ cmd_stealth() {
   if [ "$is_macos" = yes ]; then
     past=$(pbpaste)
   else
-    past=$(xsel -o)
+    if [ "$XDG_SESSION_TYPE" = wayland ]; then
+      past=$(wl-paste -p)
+    else
+      past=$(xsel -o)
+    fi
   fi
   printf "\033[0;31mstealth:\033[0m you are in the stealth mode; select any text in any window for a query\n"
   printf "\033[0;31mstealth:\033[0m selections longer than $STEALTH_MAX_SELECTION_LENGTH words are ignored\n"
@@ -686,7 +702,11 @@ cmd_stealth() {
     if [ "$is_macos" = yes ]; then
       current=$(pbpaste)
     else
-      current=$(xsel -o)
+      if [ "$XDG_SESSION_TYPE" = wayland ]; then
+        current=$(wl-paste -p)
+      else
+        current=$(xsel -o)
+      fi
     fi
     if [ "$past" != "$current" ]; then
       past=$current


### PR DESCRIPTION
This adds support for wayland (#271) using `wl-clipboard`.
Basically, if `$XDG_SESSION_TYPE` is `wayland`, instead of calling `xsel`, the corresponding `wl-(copy|pase)` command is called instead.
Stealth mode, `c` and `cc` are supported, and every `xsel` grepped has a `wl` command to compliment it.
