### PR TITLE
Also use pager for normal queries (but skip paging when output is not to a terminal)

### DIFF
--- a/share/cht.sh.txt
+++ b/share/cht.sh.txt
@@ -479,7 +479,7 @@ elif [ x"$1" = x--mode ]; then
 fi
 
 mkdir -p "$CHTSH_HOME/"
-lines=$(tput lines)
+lines=''; [ -t 1 ] && lines=$(tput lines)
 
 if command -v less >/dev/null; then
   defpager="less -R"

--- a/share/cht.sh.txt
+++ b/share/cht.sh.txt
@@ -478,6 +478,21 @@ elif [ x"$1" = x--mode ]; then
   exit "$?"
 fi
 
+mkdir -p "$CHTSH_HOME/"
+lines=$(tput lines)
+
+if command -v less >/dev/null; then
+  defpager="less -R"
+elif command -v more >/dev/null; then
+  defpager="more"
+else
+  defpager="cat"
+fi
+
+TMP1=$(mktemp /tmp/cht.sh.XXXXXXXXXXXXX)
+trap 'rm -f $TMP1 $TMP2' EXIT
+trap 'true' INT
+
 prompt="cht.sh"
 opts=""
 input=""
@@ -491,7 +506,7 @@ done
 query=$(echo "$input" | sed 's@ *$@@; s@^ *@@; s@ @/@; s@ @+@g')
 
 if [ "$shell_mode" != yes ]; then
-  curl -s "${CHTSH_URL}"/"$(get_query_options "$query")"
+  do_query "$query"
   exit 0
 else
   new_section="$1"
@@ -509,7 +524,7 @@ else
   fi
   if [ -n "$this_query" ] && [ -z "$CHEATSH_RESTART" ]; then
     printf "$this_prompt$this_query\n"
-    curl -s "${CHTSH_URL}"/"$(get_query_options "$query")"
+    do_query "$query"
   fi
 fi
 
@@ -521,17 +536,6 @@ if [ "$is_macos" != yes ]; then
   fi
 fi
 command -v rlwrap >/dev/null || { echo 'DEPENDENCY: install "rlwrap" to use cht.sh in the shell mode' >&2; exit 1; }
-
-mkdir -p "$CHTSH_HOME/"
-lines=$(tput lines)
-
-if command -v less >/dev/null; then
-  defpager="less -R"
-elif command -v more >/dev/null; then
-  defpager="more"
-else
-  defpager="cat"
-fi
 
 cmd_cd() {
   if [ $# -eq 0 ]; then
@@ -756,10 +760,6 @@ cmd_version() {
   fi
   rm -f "$TMP2" > /dev/null 2>&1
 }
-
-TMP1=$(mktemp /tmp/cht.sh.XXXXXXXXXXXXX)
-trap 'rm -f $TMP1 $TMP2' EXIT
-trap 'true' INT
 
 if ! [ -e "$CHTSH_HOME/.hushlogin" ] && [ -z "$this_query" ]; then
   echo "type 'help' for the cht.sh shell help"


### PR DESCRIPTION
I don't use `--shell` very much, rather ad-hoc `cht.sh <query>` in the shell. The paging that is used in shell mode would be helpful there as well, to avoid scrolling back in the terminal when there's long output.
The existing `do_query()` function that is used in shell mode looks like it can be a drop-in replacement for the duplicated `curl` calls, and with that we get paging for normal queries as well. (And this reuses any set session id as well.)
Some initializations need to be moved further up; they still don't run for `--help`, `--mode`, and `--standalone-install`.