### PR TITLE
Catch edge cases were delimiters are wrongfully caught

### DIFF
--- a/lib/cheat_wrapper.py
+++ b/lib/cheat_wrapper.py
@@ -26,9 +26,25 @@ def _add_section_name(query):
     if '/' in query:
         return query
     if ' ' in query:
-        # for standalone queries only that may contain ' '
-        return "%s/%s" % tuple(query.split(' ', 1))
-    return "%s/%s" % tuple(query.split('+', 1))
+        delim = " "
+    elif '+' in query:
+        delim = "+"
+
+    index = 0
+    length = len(query)
+    while index != length:
+
+        index = query.index(delim, index) + 1
+
+        try:
+            comparison = query.index(delim, index)
+        except ValueError:
+            comparison = -1
+
+        if (index != comparison and index != length):
+            return "%s/%s" % (query[:index-1], query[index:])
+
+    return query
 
 def cheat_wrapper(query, request_options=None, output_format='ansi'):
     """

--- a/lib/cheat_wrapper_test.py
+++ b/lib/cheat_wrapper_test.py
@@ -3,6 +3,10 @@ from cheat_wrapper import _add_section_name
 unchanged = """
 python/:list
 ls
++
+g++
+g/+
+clang++
 btrfs~volume
 :intro
 :cht.sh
@@ -14,6 +18,9 @@ emacs:go-mode/:list
 split = """
 python copy file
 python/copy file
+
+g++ -O1
+g++/-O1
 """
 
 def test_header_split():


### PR DESCRIPTION
related to #308

implements more robust logic that splits on the first delim it finds that isn't followed by the same delim