### PR TITLE
Fix tests by downgrading colored

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ pygments
 dateutils
 fuzzywuzzy
 redis
-colored
+colored<1.4.3
 langdetect
 cffi
 polyglot


### PR DESCRIPTION
`cheat.sh` stopped highlighting headers two weeks ago https://github.com/chubin/cheat.sh/actions/runs/1393863906