### PR TITLE
Updates to tests/run-tests.sh and tests/README.md

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
-.travis.yml
 .git
 .gitignore
 docker-compose.yml

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ typescript
 venv/
 bin/upstream
 upstream/
+tests/event_log.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,7 @@ FROM alpine:3.14
 # fetching cheat sheets
 ## installing dependencies
 RUN apk add --update --no-cache git py3-six py3-pygments py3-yaml py3-gevent \
-      libstdc++ py3-colorama py3-requests py3-icu py3-redis sed \
-      py3-setuptools  # https://gitlab.alpinelinux.org/alpine/aports/-/merge_requests/27419
+      libstdc++ py3-colorama py3-requests py3-icu py3-redis sed
 ## copying
 WORKDIR /app
 COPY . /app

--- a/README.md
+++ b/README.md
@@ -218,8 +218,7 @@ chmod +x "$PATH_DIR/cht.sh"
 or to install it globally (for all users):
 
 ```bash
-curl -s https://cht.sh/:cht.sh | sudo tee /usr/local/bin/cht.sh
-sudo chmod +x /usr/local/bin/cht.sh
+curl -s https://cht.sh/:cht.sh | sudo tee /usr/local/bin/cht.sh && sudo chmod +x /usr/local/bin/cht.sh
 ```
 
 Note: The package "rlwrap" is a required dependency to run in shell mode. Install this using `sudo apt install rlwrap`

--- a/README.md
+++ b/README.md
@@ -218,8 +218,8 @@ chmod +x "$PATH_DIR/cht.sh"
 or to install it globally (for all users):
 
 ```bash
-curl https://cht.sh/:cht.sh | sudo tee /usr/local/bin/cht.sh
-chmod +x /usr/local/bin/cht.sh
+curl -s https://cht.sh/:cht.sh | sudo tee /usr/local/bin/cht.sh
+sudo chmod +x /usr/local/bin/cht.sh
 ```
 
 Note: The package "rlwrap" is a required dependency to run in shell mode. Install this using `sudo apt install rlwrap`

--- a/doc/standalone.md
+++ b/doc/standalone.md
@@ -98,3 +98,16 @@ cheat.sh needs to access the Internet itself, because it does not have
 the necessary data locally. We are working on that how to overcome
 this limitation, but for the moment it still exists.
 
+## Mac OS X Notes
+
+### Installing Redis
+
+To install Redis on Mac OS X (using `brew`):
+
+```
+$ brew install redis
+$ ln -sfv /usr/local/opt/redis/*.plist ~/Library/LaunchAgents
+$ launchctl load ~/Library/LaunchAgents/homebrew.mxcl.redis.plist
+$ redis-cli ping
+PONG
+```

--- a/lib/adapter/git_adapter.py
+++ b/lib/adapter/git_adapter.py
@@ -43,7 +43,7 @@ class RepositoryAdapter(Adapter):
             self._cheatsheet_files_prefix,
             topic)
 
-        if os.path.exists(filename):
+        if os.path.exists(filename) and not os.path.isdir(filename):
             answer = self._format_page(open(filename, 'r').read())
         else:
             # though it should not happen

--- a/lib/adapter/git_adapter.py
+++ b/lib/adapter/git_adapter.py
@@ -124,7 +124,7 @@ class GitRepositoryAdapter(RepositoryAdapter):    #pylint: disable=abstract-meth
             raise RuntimeError(
                 "Do not known how to handle this repository: %s" % cls._repository_url)
 
-        return ['git', 'rev-parse', '--short', 'HEAD']
+        return ['git', 'rev-parse', '--short', 'HEAD', "--"]
 
     @classmethod
     def save_state(cls, state):
@@ -157,6 +157,6 @@ class GitRepositoryAdapter(RepositoryAdapter):    #pylint: disable=abstract-meth
         The list is used to invalidate the cache.
         """
         current_state = cls.get_state()
-        if current_state is None:
-            return ['git', 'ls-tree', '--full-tree', '-r', '--name-only', 'HEAD']
-        return ['git', 'diff', '--name-only', current_state, 'HEAD']
+        if not current_state:
+            return ['git', 'ls-tree', '--full-tree', '-r', '--name-only', 'HEAD', "--"]
+        return ['git', 'diff', '--name-only', current_state, 'HEAD', "--"]

--- a/lib/adapter/learnxiny.py
+++ b/lib/adapter/learnxiny.py
@@ -192,7 +192,10 @@ class LearnXYAdapter(object):
             return "\n".join(self.get_list()) + "\n"
 
         if name == ":learn":
-            return "\n".join(self._whole_cheatsheet) + "\n"
+            if self._whole_cheatsheet:
+                return "\n".join(self._whole_cheatsheet) + "\n"
+            else:
+                return ""
 
         if partial:
             possible_names = []

--- a/lib/adapter/tldr.py
+++ b/lib/adapter/tldr.py
@@ -73,15 +73,16 @@ class Tldr(GitRepositoryAdapter):
         and as soon as anything is found, format and return it.
         """
 
-        search_order = ['common', 'linux', 'osx', 'sunos', 'windows']
+        search_order = ['common', 'linux', 'osx', 'sunos', 'windows', "android"]
         local_rep = self.local_repository_location()
         ext = self._cheatsheet_files_extension
 
         filename = None
         for subdir in search_order:
-            filename = os.path.join(
+            _filename = os.path.join(
                 local_rep, 'pages', subdir, "%s%s" % (topic, ext))
-            if os.path.exists(filename):
+            if os.path.exists(_filename):
+                filename = _filename
                 break
 
         if filename:

--- a/lib/fetch.py
+++ b/lib/fetch.py
@@ -58,8 +58,8 @@ def fetch_all(skip_existing=True):
             sys.stdout.flush()
             try:
                 process = subprocess.Popen(
-                        cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
-                        universal_newlines=True)
+                    cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+                    universal_newlines=True)
             except OSError:
                 print("\nERROR: %s" % cmd)
                 raise
@@ -149,9 +149,11 @@ def _update_adapter(adptr):
     if entries:
         _log("%s Entries to be updated: %s", adptr, len(entries))
 
+    name = adptr.name()
     for entry in entries:
-        _log("+ ivalidating %s", entry)
-        cache.delete(entry)
+        cache_name = name + ":" + entry
+        _log("+ invalidating %s", cache_name)
+        cache.delete(cache_name)
 
     if entries:
         _log("Done")

--- a/lib/fetch.py
+++ b/lib/fetch.py
@@ -118,7 +118,7 @@ def _update_adapter(adptr):
 
     errorcode, output = _run_cmd(cmd)
     if errorcode:
-        _log("\nERROR:\n---\n" + output + "\n---\nCould not update %s" % adptr)
+        _log("\nERROR:\n---%s\n" % output.decode("utf-8") + "\n---\nCould not update %s" % adptr)
         return False
 
     # Getting current repository state

--- a/lib/search.py
+++ b/lib/search.py
@@ -103,6 +103,11 @@ def find_answers_by_keyword(directory, keyword, options="", request_options=None
         answer_dicts = get_answers(topic, request_options=request_options)
         for answer_dict in answer_dicts:
             answer_text = answer_dict.get('answer', '')
+            # Temporary hotfix:
+            # In some cases answer_text may be 'bytes' and not 'str'
+            if type(b"") == type(answer_text):
+                answer_text = answer_text.decode("utf-8")
+
             if match(answer_text, keyword, options_dict=options_dict):
                 answers_found.append(answer_dict)
 

--- a/share/scripts/cacheCleanup.go
+++ b/share/scripts/cacheCleanup.go
@@ -1,0 +1,52 @@
+package main
+
+// Remove invalid cache entries.
+// Cache entry is invalid, if it contains a special substring.
+
+import (
+	"context"
+	"log"
+	"strings"
+
+	"github.com/go-redis/redis"
+)
+
+var invalidEntrySubstr = "Unknown cheat sheet"
+
+func removeInvalidEntries() error {
+	rdb := redis.NewClient(&redis.Options{
+		Addr:     "localhost:6379",
+		Password: "",
+		DB:       0,
+	})
+
+	ctx := context.Background()
+	allKeys, err := rdb.Keys(ctx, "*").Result()
+	if err != nil {
+		return err
+	}
+
+	var counter int
+	for _, key := range allKeys {
+		val, err := rdb.Get(ctx, key).Result()
+		if err != nil {
+			return err
+		}
+		if strings.Contains(val, invalidEntrySubstr) {
+			err = rdb.Del(ctx, key).Err()
+			if err != nil {
+				return err
+			}
+			counter++
+		}
+	}
+	log.Println("invalid entries removed:", counter)
+	return nil
+}
+
+func main() {
+	err := removeInvalidEntries()
+	if err != nil {
+		log.Println(err)
+	}
+}

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,7 +1,42 @@
+# Testing
+
+## Setup
+
+### If you're on macOS
+
+It may be helpful to have GNU diffutils (for a mondern `diff`), GNU coreutils (for `realpath`), and GNU `sed` installed.
+
+    $ brew install diffutils
+    $ brew install coreutils
+    $ brew install gnu-sed
+
+### Install the Python dependencies
+
+    $ pip3 install --user -r ../requirements.txt
+
+### Update your local `tests/results/*` files
+
+    $ FORCE_COLOR=1 CHEATSH_UPDATE_TESTS_RESULTS=YES bash ./run-tests.sh
+
+## Running tests
+
 To run unit tests.
 
-    python3 -m pytest -v ../lib/
+    $ python3 -m pytest -v ../lib/
 
 To run input/output tests.
 
-    ./run-tests.sh
+    ## run the "standalone" tests
+    $ FORCE_COLOR=1 bash ./run-tests.sh
+
+Or:
+
+    ## run the "local server" tests
+    $ python3 ../bin/srv.py &
+    $ FORCE_COLOR=1 CHEATSH_TEST_STANDALONE=NO bash ./run-tests.sh
+
+You can also skip the "online" tests by adding `CHEATSH_TEST_SKIP_ONLINE=yes` to your `./run-tests.sh` command.
+
+### A note about `FORCE_COLOR=1`as used above.
+
+Until the future of `cheat.sh` testing has been decided, setting the environment variable `FORCE_COLOR=1` is necessary to work around some inconsistencies caused by recent changes in the Python dependency `colored`. 

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -56,7 +56,7 @@ failed=0
 
 
 while read -r number test_line; do
-  echo -e "\e[34mRunning $number: \e[36m$test_line\e[0m"
+  echo -e "\x1b[34mRunning $number: \x1b[36m$test_line\x1b[0m"
   if [ "$skip_online" = YES ]; then
     if [[ $test_line = *\[online\]* ]]; then
       echo "$number is [online]; skipping"

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -90,7 +90,7 @@ while read -r number test_line; do
     eval "curl -s $CHTSH_URL/$test_line" > "$TMP"
   fi
 
-  if ! diff -u3 results/"$number" "$TMP" > "$TMP2"; then
+  if ! diff -u results/"$number" "$TMP" > "$TMP2"; then
     if [[ $update_tests_results = NO ]]; then
       if [ "$show_details" = YES ]; then
         cat -t "$TMP2"

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -10,6 +10,11 @@
 # 2) configure CHTSH_URL
 # 3) run the script
 
+type realpath >& /dev/null ||
+realpath() {
+    [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"
+}
+
 CHTSH_SCRIPT=$(dirname "$(dirname "$(realpath "$(readlink -f "$0")")")")/share/cht.sh.txt
 
 # work from script's dir


### PR DESCRIPTION
- .dockerignore: no Travis anymore
- `gevent` dependency fix on `setuptools` is merged to Alpine
- Add cacheCleanup.go
- Fix keyword-based search (#323)
- Add -- to git commands to avoid ambiguities (fixes #303)
- Add Redis installation notes (#305)
- Fix cache invalidation (#324)
- Fix recursive search (#323)
- Fix search for uncached entries (#323)
- Improved installation instructions
- updated installation instructions
- add tests/event_log.txt to .gitignore
- realpath doesn't exist everywhere
- the escape '\e' doesn't work on old versions of bash
- drop the '-3' argument from the call to diff in tests/run-tests.sh
- update tests/README.md
