### PR TITLE
fix: if statement breaking copy() and ccopy() on macos

### DIFF
--- a/share/cht.sh.txt
+++ b/share/cht.sh.txt
@@ -559,7 +559,7 @@ cmd_cd() {
 }
 
 cmd_copy() {
-  if [ -z "$DISPLAY" ]; then
+  if [ -z "$DISPLAY" ] && [ "$is_macos" != yes ]; then
     echo copy: supported only in the Desktop version
   elif [ -z "$input" ]; then
     echo copy: Make at least one query first.
@@ -579,7 +579,7 @@ cmd_copy() {
 }
 
 cmd_ccopy() {
-  if [ -z "$DISPLAY" ]; then
+  if [ -z "$DISPLAY" ] && [ "$is_macos" != yes ]; then
     echo copy: supported only in the Desktop version
   elif [ -z "$input" ]; then
     echo copy: Make at least one query first.


### PR DESCRIPTION
Resolves issue [#361](https://github.com/chubin/cheat.sh/issues/361).

Problem: `ccopy` and `copy` return an error on mac, "copy: supported only in the Desktop version"

This is because the cht.sh script checks for presence of the `$DISPLAY` environment variable, which 
is no longer a part of MacOS as it comes from the X11 days. So, calling the function would always
return the error on mac.

[pr366](https://github.com/chubin/cheat.sh/pull/366) attempted to fix this with a similar approach.

The solution of this PR reuses the `$is_macos` boolean variable, which is already a part of this
script. 

It now only returns the error if `$DISPLAY` is null/empty *and* the OS is *not* MacOS.
