### PR TITLE
Make rfc.sh work on macos

### DIFF
--- a/share/adapters/rfc.sh
+++ b/share/adapters/rfc.sh
@@ -12,15 +12,13 @@ RFC_get()
       | sed 's/##/\n/g' \
       | sed 's/#    //g' \
       | grep -o '.*\. ' \
-      | $SED_E 's/^(.*)(January|February|March|April|May|June|July|August|September|October|November|December) [[:digit:]]{4}(.*)$/\1/'
+      | sed -E 's/^(.*)(January|February|March|April|May|June|July|August|September|October|November|December) [[:digit:]]{4}(.*)$/\1/'
   }
 
   UNAME=$(uname -s)
   if [ "$UNAME" = "Darwin" ]; then
-    SED_E="sed -E"
     SED_I="sed -i ''"
   else
-    SED_E="sed -r"
     SED_I="sed -i"
   fi
 

--- a/share/adapters/rfc.sh
+++ b/share/adapters/rfc.sh
@@ -12,8 +12,17 @@ RFC_get()
       | sed 's/##/\n/g' \
       | sed 's/#    //g' \
       | grep -o '.*\. ' \
-      | sed -r 's/^(.*)(January|February|March|April|May|June|July|August|September|October|November|December) [[:digit:]]{4}(.*)$/\1/'
+      | $SED_E 's/^(.*)(January|February|March|April|May|June|July|August|September|October|November|December) [[:digit:]]{4}(.*)$/\1/'
   }
+
+  UNAME=$(uname -s)
+  if [ "$UNAME" = "Darwin" ]; then
+    SED_E="sed -E"
+    SED_I="sed -i ''"
+  else
+    SED_E="sed -r"
+    SED_I="sed -i"
+  fi
 
   mkdir -p /tmp/RFC_get
   local WEB_RESP="/tmp/RFC_get/rfc_get_web_resp_${RANDOM}.html"
@@ -23,9 +32,11 @@ RFC_get()
   [ -f ${RFC_INDEX} ] || curl 'https://www.ietf.org/download/rfc-index.txt' 2>/dev/null > ${RFC_INDEX}
   local MIN_RFC=1
   local MAX_RFC=$(sed '/^ / d' ${RFC_INDEX} | tail -n 1 | sed 's/ .*//')
-
+  
+  local arg_lower=$(echo "$1" | tr '[:upper:]' '[:lower:]')
+  
   # Syntax check Usage statement
-  if [ $# -lt 1 ] || [[ ${1,,} == "-h" ]] || [[ ${1,,} == "--help" ]] || [[ ${1,,} == ":help" ]] || [[ ${1,,} == ":usage" ]]
+  if [ $# -lt 1 ] || [ "$arg_lower" = "-h" ] || [ "$arg_lower" = "--help" ] || [ "$arg_lower" = ":help" ] || [ "$arg_lower" = ":usage" ]
   then
     printf "
     USAGE:
@@ -80,7 +91,7 @@ RFC_get()
       fi
     fi
   # Print list of available RFCs
-  elif [[ "${1,,}" == ":list" ]]
+  elif [ "$arg_lower" = ":list" ]
   then
     # Format RFC_INDEX to show short description of each RFC
     rfc_describe \
@@ -88,7 +99,7 @@ RFC_get()
       | sed 's/ .*//; s/^0*//'
     return 0
   # Print list of available RFCs
-  elif [[ "${1,,}" == ":describe" ]]
+  elif [ "$arg_lower" = ":describe" ]
   then
     # Format RFC_INDEX to show short description of each RFC
     rfc_describe
@@ -101,7 +112,7 @@ RFC_get()
       > $WEB_RESP
   fi
   # Format nicely and print
-  sed -i '/Page [0-9]/,+2d; /page [0-9]/,+2d' ${WEB_RESP}
+  $SED_I -e '/Page [0-9]/,+2d; /page [0-9]/,+2d' ${WEB_RESP}
   if grep -q '<!DOCTYPE html>' ${WEB_RESP}
   then
     echo "Error retrieving RFC $1"
@@ -112,5 +123,4 @@ RFC_get()
     return 0
   fi
 )
-
 RFC_get "$1"


### PR DESCRIPTION
Also for some reason when running `r./share/adapters/rfc.sh` previously, I was getting the following error.
```
./share/adapters/rfc.sh: line 28: ${1,,}: bad substitution
```
I don't know the reason why, but this PR fixes this problem as well.
Did not test it on linux so please do test.

So this PR accomplishes the following:

1) Fix `bad substitution` error.
2) Make `rfc.sh` work on macos as well, because of different verions of `sed`. One being gnu's and the other one being bsd's

Thanks.