### PR TITLE
setf on point is obsolete

### DIFF
--- a/share/emacs.txt
+++ b/share/emacs.txt
@@ -59,7 +59,7 @@ text.")
          (buffer (url-retrieve-synchronously (format cheat-sh-url (url-hexify-string thing)) t t)))
     (when buffer
       (with-current-buffer buffer
-        (setf (point) (point-min))
+        (goto-char (point-min))
         (when (search-forward-regexp "^$" nil t)
           (buffer-substring (point) (point-max)))))))
 
@@ -95,7 +95,7 @@ based of the sheets that are available on cheat.sh."
   "Decorate BUFFER, finding REGEXP and setting face to FACE."
   (with-current-buffer buffer
     (save-excursion
-      (setf (point) (point-min))
+      (goto-char (point-min))
       (while (search-forward-regexp regexp nil t)
         (replace-match (propertize (match-string 1) 'font-lock-face face) nil t)))))
 


### PR DESCRIPTION
As of 29.1 point is an obsolete generalized variable. Since goto-char is available as of 18, I propose to change it to a form that won't be removed in the future.