### PR TITLE
feat: configurable Question adapter output format

### DIFF
--- a/lib/adapter/question.py
+++ b/lib/adapter/question.py
@@ -51,7 +51,7 @@ class Question(UpstreamAdapter):
     """
 
     _adapter_name = "question"
-    _output_format = "text+code"
+    _output_format = CONFIG["adapter.question.output_format"]
     _cache_needed = True
 
     def _get_page(self, topic, request_options=None):

--- a/lib/config.py
+++ b/lib/config.py
@@ -100,6 +100,7 @@ _CONFIG = {
     "adapters.mandatory": [
         "search",
     ],
+    "adapter.question.output_format": "text+code",
     "cache.redis.db": 0,
     "cache.redis.host": "localhost",
     "cache.redis.port": 6379,


### PR DESCRIPTION
Since user can use their own bin/upstream outputting in format they like, I think it is reasonable to make Question's output format configurable too